### PR TITLE
Moved ENABLE_FASTLED_PROTOCOL_SWITCHES so it is a global option

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,8 @@
 ; Default environment partitioning scheme (for S3)
 [env]
 board_build.partitions = partitions/app3M5_spiffs_4M5_8MB.csv
+build_flags =
+;    -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Linux users can uncomment this line
 
 [env:cardputer]
 platform = espressif32
@@ -39,8 +41,7 @@ build_flags =
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
+  ${env.build_flags}
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -161,8 +162,7 @@ build_flags =
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
+  ${env.build_flags}
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -277,8 +277,7 @@ lib_deps =
     nrf24/RF24@^1.5.0
 build_flags =
   -DDEVICE_M5STICK
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
+  ${env.build_flags}
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth
 
@@ -392,10 +391,9 @@ build_flags =
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
+  ${env.build_flags}
 
   -DDEVICE_S3DEVKIT
-
-;  -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -517,10 +515,9 @@ build_flags =
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
   -D BOARD_HAS_PSRAM=1
+  ${env.build_flags}
 
-  -DDEVICE_S3DEVKIT
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
+  -D DEVICE_S3DEVKIT
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -636,10 +633,9 @@ build_flags =
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
+  ${env.build_flags}
 
   -DDEVICE_M5STAMPS3
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -751,10 +747,9 @@ build_flags =
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
+  ${env.build_flags}
 
   -DDEVICE_M5STAMPS3
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -868,10 +863,9 @@ build_flags =
   -DUSER_SETUP_LOADED=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
   -include "lib/TFT_eSPI/User_Setups/Setup210_LilyGo_T_Embed_S3.h"
+  ${env.build_flags}
 
   -DDEVICE_TEMBEDS3
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -991,10 +985,9 @@ build_flags =
   -DUSER_SETUP_LOADED=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
   -include "lib/TFT_eSPI/User_Setups/Setup214_LilyGo_T_Embed_PN532.h"
+  ${env.build_flags}
   
   -DDEVICE_TEMBEDS3CC1101
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 
@@ -1111,10 +1104,9 @@ build_flags =
   -D ARDUINO_USB_MODE=1
   -D ARDUINO_USB_CDC_ON_BOOT=1
   -D CONFIG_CRC16_ENABLED=1 ; 1Wire EEPROM OneWireNg
+  ${env.build_flags}
 
   -DDEVICE_S3DEVKIT
-
-  ; -D ENABLE_FASTLED_PROTOCOL_SWITCHES ; Only possible if you build it on linux
 
   -Wl,-zmuldefs                         ; ieee80211_raw_frame_sanity_check override - needed for WiFi deauth 
 


### PR DESCRIPTION
Moved ENABLE_FASTLED_PROTOCOL_SWITCHES from each environment to a global environment and make all environment referring to the global one so enabling/disabling this option is now at a global level.

<hr>

Enabling or disabling the ENABLE_FASTLED_PROTOCOL_SWITCHES option environment by environment is tedious. I suggest the following modifications to the platformio.ini file that makes the option global.

This way, one only need to modify a single line at the beginning of the .ini file for the change to apply to all the environments simultaneously.