### PR TITLE
Fixes for webui when using on mobile

### DIFF
--- a/webui/index.h
+++ b/webui/index.h
@@ -8,7 +8,7 @@ inline const char* index_html = R"rawliteral(
   <title>ESP32 Bus Pirate</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' dominant-baseline='central' font-family='sans-serif' font-size='56' font-weight='900' fill='%2300ff00'%3EB%3C/text%3E%3C/svg%3E">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, interactive-widget=resizes-content">
 </head>
 <body>
 

--- a/webui/scripts.h
+++ b/webui/scripts.h
@@ -140,6 +140,23 @@ HIZ> `;
   const filesBtn = document.getElementById("files-btn");
   if (filesBtn) filesBtn.addEventListener("click", openFilePanel);
 
+  // Mobile keyboard: keep input visible
+  if (window.visualViewport) {
+    const main = document.querySelector("main");
+    function onViewportResize() {
+      // Use visual viewport height so the layout shrinks above the keyboard
+      main.style.height = window.visualViewport.height + "px";
+      // Prevent the page from scrolling behind the keyboard
+      window.scrollTo(0, 0);
+      document.documentElement.scrollTop = 0;
+    }
+    window.visualViewport.addEventListener("resize", onViewportResize);
+    window.visualViewport.addEventListener("scroll", function () {
+      window.scrollTo(0, 0);
+      document.documentElement.scrollTop = 0;
+    });
+  }
+
   connectSocket();
 });
 

--- a/webui/style.h
+++ b/webui/style.h
@@ -8,6 +8,7 @@ html, body {
   height: 100%; width: 100%; max-width: 100vw; max-height: 100dvh;
   font-family: Menlo, 'Courier New', Courier, 'Liberation Mono', monospace;
   background-color: #121212; color: #e0e0e0; overflow: hidden; touch-action: manipulation;
+  position: fixed; top: 0; left: 0;
 }
 main {
   display: flex; flex-direction: column; flex-grow: 1; height: 100dvh;


### PR DESCRIPTION
I've been using ESP Bus Pirate basically as an extended UART bus, and sometimes need to use it in the field using my phone. The send button and input box for commands was getting blocked by the keyboard, at least on Android with both chrome and Firefox. This PR fixes it.

After fix is applied:

<img width="1080" height="2412" alt="Screenshot_20260213-220712" src="https://github.com/user-attachments/assets/37a97664-ee46-4479-9ddf-e5fbaa99969f" />

On main, before fix:

<img width="1080" height="2412" alt="Screenshot_20260213-221042" src="https://github.com/user-attachments/assets/2b5ae683-324a-4999-b576-ae6b273f7412" />
