### PR TITLE
Added a parameter to control audio level of I2S output

### DIFF
--- a/src/Controllers/I2sController.cpp
+++ b/src/Controllers/I2sController.cpp
@@ -220,7 +220,8 @@ void I2sController::handleTestSpeaker() {
         state.getI2sLrckPin(),
         state.getI2sDataPin(),
         12000,
-        16
+        16,
+        state.getI2sMaxLevel()
     );
     
     // PCM Playback test
@@ -233,7 +234,8 @@ void I2sController::handleTestSpeaker() {
         state.getI2sLrckPin(),
         state.getI2sDataPin(),
         state.getI2sSampleRate(),
-        state.getI2sBitsPerSample()
+        state.getI2sBitsPerSample(),
+        state.getI2sMaxLevel()
     );
     
     terminalView.println("\nI2S Speaker Test: Done.");
@@ -320,6 +322,9 @@ void I2sController::handleConfig() {
     uint8_t bits = userInputManager.readValidatedUint8("Bits per sample (e.g. 16)", state.getI2sBitsPerSample());
     state.setI2sBitsPerSample(bits);
 
+    uint32_t level = userInputManager.readValidatedUint32("Max level (e.g 16383)", state.getI2sMaxLevel());
+    state.setI2sMaxLevel(min(level, (uint32_t)(1<<(bits-1) - 1)));
+
     // Config will be applied at next play/record/test action
     terminalView.println("I2S configured.\n");
 }
@@ -360,10 +365,16 @@ void I2sController::switchOutputInput(bool output) {
     if (output) {
         i2sService.configureOutput(state.getI2sBclkPin(), state.getI2sLrckPin(),
                              state.getI2sDataPin(), state.getI2sSampleRate(),
-                             state.getI2sBitsPerSample());
+                             state.getI2sBitsPerSample(), state.getI2sMaxLevel());
+        if(!i2sService.isInitialized()){
+            terminalView.println("I2S switchOutputInput: can't configure output .");
+        }
     } else {
         i2sService.configureInput(state.getI2sBclkPin(), state.getI2sLrckPin(),
                             state.getI2sDataPin(), state.getI2sSampleRate(),
                             state.getI2sBitsPerSample());
+        if(!i2sService.isInitialized()){
+            terminalView.println("I2S switchOutputInput: can't configure input .");
+        }
     }
 }

--- a/src/Controllers/SubGhzController.cpp
+++ b/src/Controllers/SubGhzController.cpp
@@ -836,7 +836,9 @@ void SubGhzController::handleListen() {
     // I2S init with configured pins
     i2sService.configureOutput(
         state.getI2sBclkPin(), state.getI2sLrckPin(), state.getI2sDataPin(),
-        state.getI2sSampleRate(), state.getI2sBitsPerSample()
+        state.getI2sSampleRate(), state.getI2sBitsPerSample(),
+        state.getI2sMaxLevel()
+
     );
 
     terminalView.println("\nSUBGHZ: RSSI to Audio mapping @ " + argTransformer.toFixed2(mhz) +

--- a/src/Services/I2sService.h
+++ b/src/Services/I2sService.h
@@ -6,7 +6,7 @@
 
 class I2sService {
 public:
-    void configureOutput(uint8_t bclk, uint8_t lrck, uint8_t dout, uint32_t sampleRate, uint8_t bits);
+    void configureOutput(uint8_t bclk, uint8_t lrck, uint8_t dout, uint32_t sampleRate, uint8_t bits, uint32_t level);
     void configureInput(uint8_t bclk, uint8_t lrck, uint8_t din,  uint32_t sampleRate, uint8_t bits);
 
     void playTone(uint32_t sampleRate, uint16_t freq, uint16_t durationMs);
@@ -27,6 +27,7 @@ private:
     uint8_t prevBclk = 0, prevLrck = 0, prevDout = 0, prevDin = 0;
     uint8_t bitsPerSample = 16;
     uint32_t sampleRateHz = 8000;
+    uint32_t maxLevel = 32767;
 
     // helpers 
     inline void writeStereo16(int16_t s);

--- a/src/States/GlobalState.h
+++ b/src/States/GlobalState.h
@@ -107,6 +107,7 @@ private:
     uint8_t i2sDataPin = 42;
     uint32_t i2sSampleRate = 44100;
     uint8_t i2sBitsPerSample = 16;
+    uint32_t i2sMaxLeveL = 32767;
 
     // CAN Default Configuration
     uint8_t canCspin = 1;
@@ -317,12 +318,14 @@ public:
     uint8_t getI2sDataPin() const { return i2sDataPin; }
     uint32_t getI2sSampleRate() const { return i2sSampleRate; }
     uint8_t getI2sBitsPerSample() const { return i2sBitsPerSample; }
+    uint32_t getI2sMaxLevel() const {return i2sMaxLeveL;}
 
     void setI2sBclkPin(uint8_t pin) { i2sBclkPin = pin; }
     void setI2sLrckPin(uint8_t pin) { i2sLrckPin = pin; }
     void setI2sDataPin(uint8_t pin) { i2sDataPin = pin; }
     void setI2sSampleRate(uint32_t rate) { i2sSampleRate = rate; }
     void setI2sBitsPerSample(uint8_t bits) { i2sBitsPerSample = bits; }
+    void setI2sMaxLevel(uint32_t level) {i2sMaxLeveL = level;}
 
     // JTAG
     const std::vector<uint8_t>& getJtagScanPins() const { return jtagScanPins; }


### PR DESCRIPTION
Added a parameter to control audio level of I2S output

State/GlobalState
        - added an i2sMaxLevel variable
        - added getter and setter for i2sMaxLevel

Services/I2sServices
        - added a private variable to hold maxlevel
        - added a level argument to configureOutput
        - added use of maxLevel in playTone(), playToneInterruptible(), playPCM().
          maxLevel is not a saturation value. It is use to rescale played value

Controllers/I2sController
        - added management of the new argument in handleConfig(), switchOutputInput()

Controllers/SubGhzController
        - added the new argument to call of i2sServices.configureOutput() in HandleListen()