### PR TITLE
fix: s3-devkit-n16-r8 pin config regression from v1.4

### DIFF
--- a/partitions/app4M_spiffs_12M_16MB.csv
+++ b/partitions/app4M_spiffs_12M_16MB.csv
@@ -1,5 +1,6 @@
-# Name,   Type, SubType, Offset,  Size, Flags
-nvs,data,nvs,0x9000,0x5000,
-app0,app,ota_0,0x10000,0x420000,
-spiffs,data,spiffs,0x430000,0xBC0000,
-coredump,data,coredump,0xFF0000,0x10000,
+# Name,     Type, SubType,  Offset,    Size,
+nvs,        data, nvs,      0x9000,    0x5000,
+phy_init,   data, phy,      0xF000,    0x1000,
+app0,       app,  factory,  0x10000,   0x420000,
+spiffs,     data, spiffs,   0x430000,  0xBC0000,
+coredump,   data, coredump, 0xFF0000,  0x10000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -481,6 +481,7 @@ build_flags =
 [env:s3-devkit-n16-r8]
 board = esp32-s3-devkitc1-n16r8
 board_build.partitions = partitions/app4M_spiffs_12M_16MB.csv
+board_build.arduino.memory_type = qio_opi
 lib_deps =
   crankyoldgit/IRremoteESP8266 @ ^2.9.0
   ${env.lib_deps}
@@ -579,6 +580,12 @@ build_flags =
 
   ; --- JTAG ---
   -DJTAG_SCAN_PINS="\"4, 5, 6, 7, 15\""
+
+  ; --- SDCARD ---
+  -DSDCARD_CS_PIN=10
+  -DSDCARD_CLK_PIN=12
+  -DSDCARD_MISO_PIN=11
+  -DSDCARD_MOSI_PIN=13
 
 
 ; =========================================================

--- a/src/Services/UsbS3Service.cpp
+++ b/src/Services/UsbS3Service.cpp
@@ -282,8 +282,6 @@ bool UsbS3Service::usbHostBegin() {
     host_cfg.root_port_unpowered = false; 
     host_cfg.intr_flags = 0;
     host_cfg.enum_filter_cb = nullptr;
-    host_cfg.fifo_settings_custom = {0, 0, 0}; 
-    host_cfg.peripheral_map = 0;
 
     esp_err_t err = usb_host_install(&host_cfg);
     if (err != ESP_OK) {


### PR DESCRIPTION
## Summary

- **Root cause**: `ledcAttachChannel()` in commit `0d21a43` (v1.4) used `channel = pin % 8`, silently breaking DIO PWM for any GPIO ≥ 8; already fixed upstream in `3d7e0a7` (`ledcAttach()` pin-indexed API)
- **Partition table**: `app4M_spiffs_12M_16MB.csv` had `ota_0` subtype with no `otadata` entry, causing `E (620) esp_ota_ops: not found otadata` on every boot; changed to `factory` + added `phy_init` to match the 8MB table pattern
- **PSRAM**: added `board_build.arduino.memory_type = qio_opi` to `[env:s3-devkit-n16-r8]` so OPI PSRAM init does not depend on the board JSON in the platform package
- **SDCARD pins**: added explicit `SDCARD_*_PIN` overrides matching the declared SPI bus (10/12/11/13); previously fell through to `GlobalState` defaults (CLK=40, MISO=39)
- **UsbS3Service**: removed `fifo_settings_custom` and `peripheral_map` fields from `usb_host_config_t` init — removed in newer ESP-IDF USB host API; struct is zero-initialized so defaults are unchanged
