### PR TITLE
Correct "E (585) esp_ota_ops: not found otadata" message after reset

### DIFF
--- a/partitions/app4M_spiffs_12M_16MB.csv
+++ b/partitions/app4M_spiffs_12M_16MB.csv
@@ -1,5 +1,6 @@
-# Name,   Type, SubType, Offset,  Size, Flags
-nvs,data,nvs,0x9000,0x5000,
-app0,app,ota_0,0x10000,0x420000,
-spiffs,data,spiffs,0x430000,0xBC0000,
-coredump,data,coredump,0xFF0000,0x10000,
+# Name,     Type, SubType,  Offset,    Size,
+nvs,        data, nvs,      0x9000,    0x5000,
+phy_init,   data, phy,      0xF000,    0x1000,
+app0,       app,  factory,  0x10000,   0x420000,
+spiffs,     data, spiffs,   0x430000,  0xBC0000,
+coredump,   data, coredump, 0xFF0000,  0x10000,


### PR DESCRIPTION
Changed partiton table as suggested in message
https://github.com/geo-tp/ESP32-Bus-Pirate/issues/103#issuecomment-4031328935

No more message after reset