### PR TITLE
Changed pin to GPIO

### DIFF
--- a/src/Analyzers/PinAnalyzer.cpp
+++ b/src/Analyzers/PinAnalyzer.cpp
@@ -553,7 +553,7 @@ PinAnalyzer::Report PinAnalyzer::buildReport(bool doPullTest) {
 std::string PinAnalyzer::formatWizardReport(uint8_t pin, const Report& r) const {
     std::ostringstream oss;
 
-    oss << "[Wizard report on pin " << (int)pin << "]\r\n";
+    oss << "[Wizard report on GPIO " << (int)pin << "]\r\n";
 
     auto line = [&](const std::string& s) {
         oss << "  " << s << "\r\n";

--- a/src/Controllers/CanController.cpp
+++ b/src/Controllers/CanController.cpp
@@ -177,20 +177,20 @@ void CanController::handleConfig() {
 
     // CS pin is fixed, no need to configure
     uint8_t cs = state.getCanCspin();
-    terminalView.print("MCP2515 CS pin is fixed to: " + std::to_string(cs));
+    terminalView.print("MCP2515 CS GPIO is fixed to: " + std::to_string(cs));
     terminalInput.waitPress();
     terminalView.println("");
 
     // Configure SCK
-    uint8_t sck = userInputManager.readValidatedPinNumber("MCP2515 SCK pin", state.getCanSckPin(), forbidden);
+    uint8_t sck = userInputManager.readValidatedPinNumber("MCP2515 SCK GPIO", state.getCanSckPin(), forbidden);
     state.setCanSckPin(sck);
 
     // Configure SI (MOSI)
-    uint8_t si = userInputManager.readValidatedPinNumber("MCP2515 SI (MOSI) pin", state.getCanSiPin(), forbidden);
+    uint8_t si = userInputManager.readValidatedPinNumber("MCP2515 SI (MOSI) GPIO", state.getCanSiPin(), forbidden);
     state.setCanSiPin(si);
 
     // Configure SO (MISO)
-    uint8_t so = userInputManager.readValidatedPinNumber("MCP2515 SO (MISO) pin", state.getCanSoPin(), forbidden);
+    uint8_t so = userInputManager.readValidatedPinNumber("MCP2515 SO (MISO) GPIO", state.getCanSoPin(), forbidden);
     state.setCanSoPin(so);
 
     // Configure bitrate

--- a/src/Controllers/CellController.cpp
+++ b/src/Controllers/CellController.cpp
@@ -67,10 +67,10 @@ void CellController::handleConfig()
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t rx = userInputManager.readValidatedPinNumber("MODEM RX", state.getUartRxPin(), forbidden);
+    uint8_t rx = userInputManager.readValidatedPinNumber("MODEM RX GPIO", state.getUartRxPin(), forbidden);
     state.setUartRxPin(rx);
 
-    uint8_t tx = userInputManager.readValidatedPinNumber("MODEM TX", state.getUartTxPin(), forbidden);
+    uint8_t tx = userInputManager.readValidatedPinNumber("MODEM TX GPIO", state.getUartTxPin(), forbidden);
     state.setUartTxPin(tx);
 
     const uint32_t defaultModemBaud = 115200; // common default baudrate for modems
@@ -84,7 +84,7 @@ void CellController::handleConfig()
     if (!cellService.detect()) {
         terminalView.println("❌ No modem detected.");
         terminalView.println("It may take up 30 sec to start.");
-        terminalView.println("Try to swap RX and TX pins.\n");
+        terminalView.println("Try to swap RX and TX GPIOs.\n");
         return;
     }
 

--- a/src/Controllers/DioController.cpp
+++ b/src/Controllers/DioController.cpp
@@ -49,14 +49,14 @@ Read
 */
 void DioController::handleReadPin(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: read <pin>");
+        terminalView.println("Usage: read <GPIO>");
         return;
     }
 
     uint8_t pin = argTransformer.toUint8(cmd.getSubcommand());
     if (!isPinAllowed(pin, "Read")) return;
     int value = pinService.read(pin);
-    terminalView.println("Pin " + std::to_string(pin) + " = " + std::to_string(value) + (value ? " (HIGH)" : " (LOW)"));
+    terminalView.println("GPIO " + std::to_string(pin) + " = " + std::to_string(value) + (value ? " (HIGH)" : " (LOW)"));
 }
 
 /*
@@ -64,7 +64,7 @@ Set
 */
 void DioController::handleSetPin(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: set <pin> <IN/OUT/HI/LOW>");
+        terminalView.println("Usage: set <GPIO> <IN/OUT/HI/LOW>");
         return;
     }
 
@@ -81,11 +81,11 @@ void DioController::handleSetPin(const TerminalCommand& cmd) {
     switch (c) {
         case 'I':
             pinService.setInput(pin);
-            terminalView.println("DIO Set: Pin " + std::to_string(pin) + " set to INPUT");
+            terminalView.println("DIO Set: GPIO " + std::to_string(pin) + " set to INPUT");
             break;
         case 'O':
             pinService.setOutput(pin);
-            terminalView.println("DIO Set: Pin " + std::to_string(pin) + " set to OUTPUT");
+            terminalView.println("DIO Set: GPIO " + std::to_string(pin) + " set to OUTPUT");
             break;
         case 'H':
         case '1':
@@ -125,7 +125,7 @@ void DioController::handleScan(const TerminalCommand& cmd) {
 
     // Limit
     if (pins.size() > 8) {
-        terminalView.println("Too many pins selected, limiting to first 8.");
+        terminalView.println("Too many GPIOs selected, limiting to first 8.");
         pins.resize(8);
     }
 
@@ -139,7 +139,7 @@ void DioController::handleScan(const TerminalCommand& cmd) {
     }
 
     if (validPins.empty()) {
-        terminalView.println("DIO Scan: No valid pins selected.");
+        terminalView.println("DIO Scan: No valid GPIOs selected.");
         return;
     }
 
@@ -205,7 +205,7 @@ void DioController::handleScan(const TerminalCommand& cmd) {
         if (now - lastPrint >= 2000) {
             lastPrint = now;
 
-            terminalView.println("Active pins:");
+            terminalView.println("Active GPIOs:");
 
             // Find max digits for align
             size_t maxEdgeDigits = 1;
@@ -306,7 +306,7 @@ void DioController::handlePins(const TerminalCommand& cmd) {
     }
 
     if (validPins.empty()) {
-        terminalView.println("\nDIO Pins: No usable pins (all protected?).\n");
+        terminalView.println("\nDIO Pins: No usable GPIOs (all protected?).\n");
         return;
     }
 
@@ -344,7 +344,7 @@ Pullup
 */
 void DioController::handlePullup(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: pullup <pin>");
+        terminalView.println("Usage: pullup <GPIO>");
         return;
     }
 
@@ -352,7 +352,7 @@ void DioController::handlePullup(const TerminalCommand& cmd) {
     if (!isPinAllowed(pin, "Pullup")) return;
     pinService.setInputPullup(pin);
 
-    terminalView.println("DIO Pullup: Set on pin " + std::to_string(pin));
+    terminalView.println("DIO Pullup: Set on GPIO " + std::to_string(pin));
 }
 
 /*
@@ -360,7 +360,7 @@ Pulldown
 */
 void DioController::handlePulldown(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: pulldown <pin>");
+        terminalView.println("Usage: pulldown <GPIO>");
         return;
     }
 
@@ -368,7 +368,7 @@ void DioController::handlePulldown(const TerminalCommand& cmd) {
     if (!isPinAllowed(pin, "Pulldown")) return;
     pinService.setInputPullDown(pin);
 
-    terminalView.println("DIO Pulldown: Set on pin " + std::to_string(pin));
+    terminalView.println("DIO Pulldown: Set on GPIO " + std::to_string(pin));
 }
 
 /*
@@ -376,7 +376,7 @@ Sniff
 */
 void DioController::handleSniff(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: sniff <pin>");
+        terminalView.println("Usage: sniff <GPIO>");
         return;
     }
 
@@ -389,7 +389,7 @@ void DioController::handleSniff(const TerminalCommand& cmd) {
     else if (pull == PinService::PULL_DOWN) pinService.setInputPullDown(pin);
     else                                   pinService.setInput(pin);
 
-    terminalView.println("DIO Sniff: Pin " + std::to_string(pin) + "... Press [ENTER] to stop");
+    terminalView.println("DIO Sniff: GPIO " + std::to_string(pin) + "... Press [ENTER] to stop");
     uint8_t last = pinService.read(pin);
     terminalView.println("\nInitial state: " + std::string(last ? "HIGH" : "LOW"));
     terminalView.println("");
@@ -419,7 +419,7 @@ void DioController::handleSniff(const TerminalCommand& cmd) {
                 : "HIGH -> LOW ";
 
             terminalView.println(
-                "Pin " + std::to_string(pin) + ": " + transition +
+                "GPIO " + std::to_string(pin) + ": " + transition +
                 " | delta=" + std::to_string(dtUs) + "us"
             );
 
@@ -435,9 +435,9 @@ void DioController::handlePwm(const TerminalCommand& cmd) {
     auto sub = cmd.getSubcommand();
     auto args = argTransformer.splitArgs(cmd.getArgs());
 
-    // Validate pin
+    // Validate GPIO
     if (sub.empty() || !argTransformer.isValidNumber(sub)) {
-        terminalView.println("Usage: pwm <pin> [frequency] [duty]");
+        terminalView.println("Usage: pwm <GPIO> [frequency] [duty]");
         return;
     }
 
@@ -471,7 +471,7 @@ void DioController::handlePwm(const TerminalCommand& cmd) {
          return;
     }
 
-    terminalView.println("\nDIO PWM: Pin " + std::to_string(pin) +
+    terminalView.println("\nDIO PWM: GPIO " + std::to_string(pin) +
                          " (" + std::to_string(freq) + "Hz, " +
                          std::to_string(duty) + "% duty)... Use 'reset " + 
                          std::to_string(pin) + "' to stop.\n");
@@ -485,12 +485,12 @@ void DioController::handleMeasure(const TerminalCommand& cmd) {
     auto args = argTransformer.splitArgs(cmd.getArgs());
 
     if (cmd.getSubcommand().empty()) {
-        terminalView.println("Usage: measure <pin> [duration_ms]");
+        terminalView.println("Usage: measure <GPIO> [duration_ms]");
         return;
     }
 
     if (!argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("DIO Measure: Invalid pin number.");
+        terminalView.println("DIO Measure: Invalid GPIO number.");
         return;
     }
 
@@ -505,7 +505,7 @@ void DioController::handleMeasure(const TerminalCommand& cmd) {
         }
     }
 
-    terminalView.println("DIO Measure: Sampling pin " + std::to_string(pin) +
+    terminalView.println("DIO Measure: Sampling GPIO " + std::to_string(pin) +
                          " for " + std::to_string(durationMs) + " ms...");
 
     PinService::pullType pull =  pinService.getPullType(pin);
@@ -562,7 +562,7 @@ void DioController::handleTogglePin(const TerminalCommand& cmd) {
     auto args = argTransformer.splitArgs(cmd.getArgs());
     
     if (cmd.getSubcommand().empty() || args.empty()) {
-        terminalView.println("Usage: toggle <pin> <ms>");
+        terminalView.println("Usage: toggle <GPIO> <ms>");
         return;
     }
     
@@ -580,7 +580,7 @@ void DioController::handleTogglePin(const TerminalCommand& cmd) {
     pinService.setOutput(pin);
     bool state = false;
 
-    terminalView.println("\nDIO Toggle: Pin " + std::to_string(pin) + " every " + std::to_string(intervalMs) + "ms...Press [ENTER] to stop.");
+    terminalView.println("\nDIO Toggle: GPIO " + std::to_string(pin) + " every " + std::to_string(intervalMs) + "ms...Press [ENTER] to stop.");
     terminalView.println("");
 
     unsigned long lastToggle = millis();
@@ -599,7 +599,7 @@ void DioController::handleTogglePin(const TerminalCommand& cmd) {
             }
         }
 
-        // toggle pin at defined interval
+        // toggle GPIO at defined interval
         if (now - lastToggle >= intervalMs) {
             lastToggle = now;
             state = !state;
@@ -617,12 +617,12 @@ Reset
 */
 void DioController::handleResetPin(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty()) {
-        terminalView.println("Usage: reset <pin>");
+        terminalView.println("Usage: reset <GPIO>");
         return;
     }
 
     if (!argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("DIO Reset: Invalid pin number.");
+        terminalView.println("DIO Reset: Invalid GPIO number.");
         return;
     }
 
@@ -634,12 +634,12 @@ void DioController::handleResetPin(const TerminalCommand& cmd) {
     // Reset Pullup
     pinService.setInput(pin);
 
-    terminalView.println("DIO Reset: Pin " + std::to_string(pin) + " to INPUT (no pull-up, no PWM).");
+    terminalView.println("DIO Reset: GPIO " + std::to_string(pin) + " to INPUT (no pull-up, no PWM).");
 }
 
 void DioController::handleServo(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || cmd.getArgs().empty()) {
-        terminalView.println("Usage: servo <pin> <angle>");
+        terminalView.println("Usage: servo <GPIO> <angle>");
         return;
     }
 
@@ -654,7 +654,7 @@ void DioController::handleServo(const TerminalCommand& cmd) {
 
     uint8_t angle = argTransformer.parseHexOrDec(cmd.getArgs());
     pinService.setServoAngle(pin, angle);
-    terminalView.println("DIO Servo: Set pin " + std::to_string(pin) + 
+    terminalView.println("DIO Servo: Set GPIO " + std::to_string(pin) + 
                          " to angle " + std::to_string(angle) + 
                          "... Use 'reset " + std::to_string(pin) + "' to stop.");
 }
@@ -664,7 +664,7 @@ Pulse
 */
 void DioController::handlePulse(const TerminalCommand& cmd) {
     if (cmd.getSubcommand().empty() || cmd.getArgs().empty()) {
-        terminalView.println("Usage: pulse <pin> <duration_us>");
+        terminalView.println("Usage: pulse <GPIO> <duration_us>");
         return;
     }
 
@@ -696,7 +696,7 @@ void DioController::handlePulse(const TerminalCommand& cmd) {
     else      pinService.setLow(pin);
 
     terminalView.println(
-        "DIO Pulse: Pin " + std::to_string(pin) +
+        "DIO Pulse: GPIO " + std::to_string(pin) +
         " pulsed " + std::string(pulseLevel ? "HIGH" : "LOW") +
         " for " + std::to_string(durationUs) + " us."
     );
@@ -712,7 +712,7 @@ void DioController::handleJamPin(const TerminalCommand& cmd) {
     uint32_t maxUs = 100;
 
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: jam <pin> [min_us] [max_us]");
+        terminalView.println("Usage: jam <GPIO> [min_us] [max_us]");
         return;
     }
 
@@ -732,7 +732,7 @@ void DioController::handleJamPin(const TerminalCommand& cmd) {
 
     pinService.setOutput(pin);
 
-    terminalView.println("DIO Jam: Pin " + std::to_string(pin) +
+    terminalView.println("DIO Jam: GPIO " + std::to_string(pin) +
                          " random toggle [" + std::to_string(minUs) + ".." + std::to_string(maxUs) +
                          "] us... Press [ENTER] to stop.");
     terminalView.println("");
@@ -774,17 +774,17 @@ bool DioController::isPinAllowed(uint8_t pin, const std::string& context) {
     const auto& protectedPins = state.getProtectedPins();
     
     if (std::find(protectedPins.begin(), protectedPins.end(), pin) != protectedPins.end()) {
-        terminalView.println("DIO " + context + ": Pin " + std::to_string(pin) + " is protected and cannot be used.");
+        terminalView.println("DIO " + context + ": GPIO " + std::to_string(pin) + " is protected and cannot be used.");
         return false;
     }
 
     if (pin > 48 /* max pin for S3 */) {
-        terminalView.println("DIO " + context + ": Pin " + std::to_string(pin) + " is out of range (0-48).");
+        terminalView.println("DIO " + context + ": GPIO " + std::to_string(pin) + " is out of range (0-48).");
         return false;
     }
 
     if (pin < 0) {
-        terminalView.println("DIO " + context + ": Pin " + std::to_string(pin) + " is invalid.");
+        terminalView.println("DIO " + context + ": GPIO " + std::to_string(pin) + " is invalid.");
         return false;
     }
 

--- a/src/Controllers/EthernetController.cpp
+++ b/src/Controllers/EthernetController.cpp
@@ -62,21 +62,21 @@ void EthernetController::handleConfig() {
     uint32_t defHz  = state.getEthernetFrequency();
 
     // User input for configuration
-    uint8_t cs   = userInputManager.readValidatedPinNumber("W5500 CS pin",   defCS,   forbidden);
-    uint8_t sck  = userInputManager.readValidatedPinNumber("W5500 SCK pin",  defSCK,  forbidden);
-    uint8_t miso = userInputManager.readValidatedPinNumber("W5500 MISO pin", defMISO, forbidden);
-    uint8_t mosi = userInputManager.readValidatedPinNumber("W5500 MOSI pin", defMOSI, forbidden);
-    uint8_t irq  = userInputManager.readValidatedPinNumber("W5500 IRQ pin",  defIRQ,  forbidden);
+    uint8_t cs   = userInputManager.readValidatedPinNumber("W5500 CS GPIO",   defCS,   forbidden);
+    uint8_t sck  = userInputManager.readValidatedPinNumber("W5500 SCK GPIO",  defSCK,  forbidden);
+    uint8_t miso = userInputManager.readValidatedPinNumber("W5500 MISO GPIO", defMISO, forbidden);
+    uint8_t mosi = userInputManager.readValidatedPinNumber("W5500 MOSI GPIO", defMOSI, forbidden);
+    uint8_t irq  = userInputManager.readValidatedPinNumber("W5500 IRQ GPIO",  defIRQ,  forbidden);
 
     // RST optional
     bool useReset = userInputManager.readYesNo(
-        "Use a RESET (RST) pin?",
+        "Use a RESET (RST) GPIO?",
         false
     );
 
     uint8_t rst = 255;
     if (useReset) {
-        rst = userInputManager.readValidatedPinNumber("W5500 RST pin", rst, forbidden);
+        rst = userInputManager.readValidatedPinNumber("W5500 RST GPIO", rst, forbidden);
     }
 
     // Frequency SPI

--- a/src/Controllers/ExpanderController.cpp
+++ b/src/Controllers/ExpanderController.cpp
@@ -114,14 +114,14 @@ void ExpanderController::handleConfig() {
     const auto& forbidden = state.getProtectedPins();
 
     uint8_t rxPin = userInputManager.readValidatedPinNumber(
-        "RX pin number",
+        "RX GPIO number",
         state.getUartRxPin(),
         forbidden
     );
     state.setUartRxPin(rxPin);
 
     uint8_t txPin = userInputManager.readValidatedPinNumber(
-        "TX pin number",
+        "TX GPIO number",
         state.getUartTxPin(),
         forbidden
     );
@@ -183,7 +183,7 @@ void ExpanderController::handleConfig() {
 
     if (!handshakeOk) {
         terminalView.println("Expander handshake failed.");
-        terminalView.println("Try to swap RX/TX pins.");
+        terminalView.println("Try to swap RX/TX GPIOs.");
         terminalView.println("Ensure the Expander is powered.\n");
         configured = false;
         state.setCurrentMode(ModeEnum::HIZ);

--- a/src/Controllers/FmController.cpp
+++ b/src/Controllers/FmController.cpp
@@ -58,7 +58,7 @@ bool FmController::ensurePresent_() {
 
     if (!fmService.begin()) {
         terminalView.println("FM: SI4713 not detected (I2C 0x63).");
-        terminalView.println("Tip: check wiring, reset pin required\n");
+        terminalView.println("Tip: check wiring, reset GPIO required\n");
         return false;
     }
     return true;
@@ -74,15 +74,15 @@ void FmController::handleConfig() {
     const auto& forbidden = state.getProtectedPins();
 
     // I2C
-    uint8_t sdaPin = (uint8_t)userInputManager.readValidatedPinNumber("SI4713 SDA pin", state.getTwoWireIoPin(), forbidden);
-    uint8_t sclPin = (uint8_t)userInputManager.readValidatedPinNumber("SI4713 SCL pin", state.getTwoWireClkPin(), forbidden);
+    uint8_t sdaPin = (uint8_t)userInputManager.readValidatedPinNumber("SI4713 SDA GPIO", state.getTwoWireIoPin(), forbidden);
+    uint8_t sclPin = (uint8_t)userInputManager.readValidatedPinNumber("SI4713 SCL GPIO", state.getTwoWireClkPin(), forbidden);
 
     // RST
     terminalView.println("\n [ℹ️  INFORMATIONS]");
-    terminalView.println(" Reset pin is required, or you can");
+    terminalView.println(" Reset GPIO is required, or you can");
     terminalView.println(" briefly connect SI4713 RST to GND");
     terminalView.println(" to activate the device.\n");
-    int8_t resetPin = (int8_t)userInputManager.readValidatedPinNumber("SI4713 RESET pin", state.getTwoWireRstPin(), forbidden); // -1 = none
+    int8_t resetPin = (int8_t)userInputManager.readValidatedPinNumber("SI4713 RESET GPIO", state.getTwoWireRstPin(), forbidden); // -1 = none
 
     // Freq
     uint32_t i2cFreqHz = userInputManager.readValidatedUint32("I2C frequency (Hz)", state.getI2cFrequency());
@@ -439,7 +439,7 @@ void FmController::handleBroadcast() {
 Reset
 */
 void FmController::handleReset() {
-    terminalView.println("FM: Resetting SI4713 via reset pin...");
+    terminalView.println("FM: Resetting SI4713 via reset GPIO...");
     fmService.reset(state.getTwoWireRstPin());
 }
 

--- a/src/Controllers/HdUartController.cpp
+++ b/src/Controllers/HdUartController.cpp
@@ -73,7 +73,7 @@ void HdUartController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t pin = userInputManager.readValidatedPinNumber("Shared TX/RX pin", state.getHdUartPin(), forbidden);
+    uint8_t pin = userInputManager.readValidatedPinNumber("Shared TX/RX GPIO", state.getHdUartPin(), forbidden);
     state.setHdUartPin(pin);
 
     uint32_t baud = userInputManager.readValidatedUint32("Baud rate", state.getHdUartBaudRate());
@@ -119,7 +119,7 @@ void HdUartController::ensureConfigured() {
 
     hdUartService.end();
 
-    // User could have set the same pin to a different usage
+    // User could have set the same GPIO to a different usage
     // eg. select UART, then select I2C, then select UART
     // Always reconfigure pins before use
     auto rx = state.getHdUartPin();

--- a/src/Controllers/I2cController.cpp
+++ b/src/Controllers/I2cController.cpp
@@ -296,10 +296,10 @@ void I2cController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t sda = userInputManager.readValidatedPinNumber("SDA pin", state.getI2cSdaPin(), forbidden);
+    uint8_t sda = userInputManager.readValidatedPinNumber("SDA GPIO", state.getI2cSdaPin(), forbidden);
     state.setI2cSdaPin(sda);
 
-    uint8_t scl = userInputManager.readValidatedPinNumber("SCL pin", state.getI2cSclPin(), forbidden);
+    uint8_t scl = userInputManager.readValidatedPinNumber("SCL GPIO", state.getI2cSclPin(), forbidden);
     state.setI2cSclPin(scl);
 
     uint32_t freq = userInputManager.readValidatedUint32("Frequency", state.getI2cFrequency());

--- a/src/Controllers/I2sController.cpp
+++ b/src/Controllers/I2sController.cpp
@@ -166,7 +166,7 @@ void I2sController::handleTestSpeaker() {
 
     auto rate = state.getI2sSampleRate();
 
-    terminalView.println("Using pins:");
+    terminalView.println("Using GPIOs:");
     terminalView.println("  BCLK : " + std::to_string(state.getI2sBclkPin()));
     terminalView.println("  LRCK : " + std::to_string(state.getI2sLrckPin()));
     terminalView.println("  DATA : " + std::to_string(state.getI2sDataPin()));
@@ -278,7 +278,7 @@ void I2sController::handleTestMic() {
     terminalView.println("\nI2S Micro: Analyzing input signal...\n");
 
     // Show pin config
-    terminalView.println("Using pins:");
+    terminalView.println("Using GPIOs:");
     terminalView.println("  BCLK : " + std::to_string(state.getI2sBclkPin()));
     terminalView.println("  LRCK : " + std::to_string(state.getI2sLrckPin()));
     terminalView.println("  DATA : " + std::to_string(state.getI2sDataPin()));
@@ -336,13 +336,13 @@ void I2sController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t bclk = userInputManager.readValidatedPinNumber("BCLK pin", state.getI2sBclkPin(), forbidden);
+    uint8_t bclk = userInputManager.readValidatedPinNumber("BCLK GPIO", state.getI2sBclkPin(), forbidden);
     state.setI2sBclkPin(bclk);
 
-    uint8_t lrck = userInputManager.readValidatedPinNumber("LRCK/WS pin", state.getI2sLrckPin(), forbidden);
+    uint8_t lrck = userInputManager.readValidatedPinNumber("LRCK/WS GPIO", state.getI2sLrckPin(), forbidden);
     state.setI2sLrckPin(lrck);
 
-    uint8_t data = userInputManager.readValidatedPinNumber("DATA pin", state.getI2sDataPin(), forbidden);
+    uint8_t data = userInputManager.readValidatedPinNumber("DATA GPIO", state.getI2sDataPin(), forbidden);
     state.setI2sDataPin(data);
 
     uint32_t freq = userInputManager.readValidatedUint32("Sample rate (e.g. 44100)", state.getI2sSampleRate());

--- a/src/Controllers/InfraredController.cpp
+++ b/src/Controllers/InfraredController.cpp
@@ -611,8 +611,8 @@ void InfraredController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t txPin = userInputManager.readValidatedPinNumber("Infrared TX pin", state.getInfraredTxPin(), forbidden);
-    uint8_t rxPin = userInputManager.readValidatedPinNumber("Infrared RX pin", state.getInfraredRxPin(), forbidden);
+    uint8_t txPin = userInputManager.readValidatedPinNumber("Infrared TX GPIO", state.getInfraredTxPin(), forbidden);
+    uint8_t rxPin = userInputManager.readValidatedPinNumber("Infrared RX GPIO", state.getInfraredRxPin(), forbidden);
 
     state.setInfraredTxPin(txPin);
     state.setInfraredRxPin(rxPin);

--- a/src/Controllers/JtagController.cpp
+++ b/src/Controllers/JtagController.cpp
@@ -121,7 +121,7 @@ void JtagController::handleConfig() {
     state.setJtagScanPins(selectedPins);
 
     // Show confirmation
-    terminalView.print("Pins set for the scan (SWD/JTAG): ");
+    terminalView.print("GPIOs set for the scan (SWD/JTAG): ");
     for (uint8_t pin : selectedPins) {
         terminalView.print(std::to_string(pin) + " ");
     }

--- a/src/Controllers/LedController.cpp
+++ b/src/Controllers/LedController.cpp
@@ -68,7 +68,7 @@ void LedController::handleScan() {
         ? LedService::getSingleWireProtocols()
         : LedService::getSpiChipsets();
 
-    // Get saved pins and leds count
+    // Get saved GPIOs and leds count
     uint8_t dataPin = state.getLedDataPin();
     uint8_t clockPin = state.getLedClockPin();
     uint16_t length = state.getLedLength();
@@ -197,8 +197,8 @@ void LedController::handleConfig() {
 
     // LEDs pins, locked because FastLED needs them at compile time
     terminalView.println("\n [⚠️  WARNING]");
-    terminalView.println(" Data pin cannot be changed. Set to : " + std::to_string(defaultDataPin));
-    terminalView.println(" Clock pin cannot be changed. Set to: " + std::to_string(defaultClockPin));
+    terminalView.println(" Data GPIO cannot be changed. Set to : " + std::to_string(defaultDataPin));
+    terminalView.println(" Clock GPIO cannot be changed. Set to: " + std::to_string(defaultClockPin));
     terminalView.println("");
 
     // LEDs count

--- a/src/Controllers/OneWireController.cpp
+++ b/src/Controllers/OneWireController.cpp
@@ -354,7 +354,7 @@ void OneWireController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t pin = userInputManager.readValidatedPinNumber("Data pin", state.getOneWirePin(), forbidden);
+    uint8_t pin = userInputManager.readValidatedPinNumber("Data GPIO", state.getOneWirePin(), forbidden);
     state.setOneWirePin(pin);
     oneWireService.configure(pin);
 

--- a/src/Controllers/Rf24Controller.cpp
+++ b/src/Controllers/Rf24Controller.cpp
@@ -575,11 +575,11 @@ void Rf24Controller::handleSetChannel() {
 NRF24 Configuration
 */
 void Rf24Controller::handleConfig() {
-    uint8_t csn = userInputManager.readValidatedInt("NRF24 CSN pin?", state.getRf24CsnPin());
-    uint8_t sck  = userInputManager.readValidatedInt("NRF24 SCK pin?", state.getRf24SckPin());
-    uint8_t miso = userInputManager.readValidatedInt("NRF24 MISO pin?", state.getRf24MisoPin());
-    uint8_t mosi = userInputManager.readValidatedInt("NRF24 MOSI pin?", state.getRf24MosiPin());
-    uint8_t ce  = userInputManager.readValidatedInt("NRF24 CE pin?", state.getRf24CePin());
+    uint8_t csn = userInputManager.readValidatedInt("NRF24 CSN GPIO?", state.getRf24CsnPin());
+    uint8_t sck  = userInputManager.readValidatedInt("NRF24 SCK GPIO?", state.getRf24SckPin());
+    uint8_t miso = userInputManager.readValidatedInt("NRF24 MISO GPIO?", state.getRf24MisoPin());
+    uint8_t mosi = userInputManager.readValidatedInt("NRF24 MOSI GPIO?", state.getRf24MosiPin());
+    uint8_t ce  = userInputManager.readValidatedInt("NRF24 CE GPIO?", state.getRf24CePin());
     state.setRf24CsnPin(csn);
     state.setRf24SckPin(sck);
     state.setRf24MisoPin(miso);

--- a/src/Controllers/RfidController.cpp
+++ b/src/Controllers/RfidController.cpp
@@ -320,10 +320,10 @@ void RfidController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t sda = userInputManager.readValidatedPinNumber("PN532 SDA pin", state.getRfidSdaPin(), forbidden);
+    uint8_t sda = userInputManager.readValidatedPinNumber("PN532 SDA GPIO", state.getRfidSdaPin(), forbidden);
     state.setRfidSdaPin(sda);
 
-    uint8_t scl = userInputManager.readValidatedPinNumber("PN532 SCL pin", state.getRfidSclPin(), forbidden);
+    uint8_t scl = userInputManager.readValidatedPinNumber("PN532 SCL GPIO", state.getRfidSclPin(), forbidden);
     state.setRfidSclPin(scl);
 
     // Configure + begin

--- a/src/Controllers/SpiController.cpp
+++ b/src/Controllers/SpiController.cpp
@@ -228,16 +228,16 @@ void SpiController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t mosi = userInputManager.readValidatedPinNumber("MOSI pin", state.getSpiMOSIPin(), forbidden);
+    uint8_t mosi = userInputManager.readValidatedPinNumber("MOSI GPIO", state.getSpiMOSIPin(), forbidden);
     state.setSpiMOSIPin(mosi);
 
-    uint8_t miso = userInputManager.readValidatedPinNumber("MISO pin", state.getSpiMISOPin(), forbidden);
+    uint8_t miso = userInputManager.readValidatedPinNumber("MISO GPIO", state.getSpiMISOPin(), forbidden);
     state.setSpiMISOPin(miso);
 
-    uint8_t sclk = userInputManager.readValidatedPinNumber("SCLK pin", state.getSpiCLKPin(), forbidden);
+    uint8_t sclk = userInputManager.readValidatedPinNumber("SCLK GPIO", state.getSpiCLKPin(), forbidden);
     state.setSpiCLKPin(sclk);
 
-    uint8_t cs = userInputManager.readValidatedPinNumber("CS pin", state.getSpiCSPin(), forbidden);
+    uint8_t cs = userInputManager.readValidatedPinNumber("CS GPIO", state.getSpiCSPin(), forbidden);
     state.setSpiCSPin(cs);
 
     uint32_t freqMhz = state.getSpiFrequency() / 1000000;

--- a/src/Controllers/SubGhzController.cpp
+++ b/src/Controllers/SubGhzController.cpp
@@ -927,7 +927,7 @@ void SubGhzController::handleEar() {
                          " MHz... Press [ENTER] to stop.\n");
 
     terminalView.println(" [ℹ️  INFORMATION] ");
-    terminalView.println(" Using I2S configured pins for audio output.");
+    terminalView.println(" Using I2S configured GPIOs for audio output.");
     terminalView.println(" You can set volume in the I2S mode settings.\n");
 
     // Mapping params
@@ -1039,19 +1039,19 @@ void SubGhzController::handleConfig() {
     const auto& forbidden = state.getProtectedPins();    
 
     // CC1101 pins
-    uint8_t sck  = userInputManager.readValidatedPinNumber("CC1101 SCK pin",  state.getSubGhzSckPin(),  forbidden);
+    uint8_t sck  = userInputManager.readValidatedPinNumber("CC1101 SCK GPIO",  state.getSubGhzSckPin(),  forbidden);
     state.setSubGhzSckPin(sck);
 
-    uint8_t miso = userInputManager.readValidatedPinNumber("CC1101 MISO pin", state.getSubGhzMisoPin(), forbidden);
+    uint8_t miso = userInputManager.readValidatedPinNumber("CC1101 MISO GPIO", state.getSubGhzMisoPin(), forbidden);
     state.setSubGhzMisoPin(miso);
 
-    uint8_t mosi = userInputManager.readValidatedPinNumber("CC1101 MOSI pin", state.getSubGhzMosiPin(), forbidden);
+    uint8_t mosi = userInputManager.readValidatedPinNumber("CC1101 MOSI GPIO", state.getSubGhzMosiPin(), forbidden);
     state.setSubGhzMosiPin(mosi);
 
-    uint8_t ss   = userInputManager.readValidatedPinNumber("CC1101 SS/CS pin", state.getSubGhzCsPin(), forbidden);
+    uint8_t ss   = userInputManager.readValidatedPinNumber("CC1101 SS/CS GPIO", state.getSubGhzCsPin(), forbidden);
     state.setSubGhzCsPin(ss);
 
-    uint8_t gdo0 = userInputManager.readValidatedPinNumber("CC1101 GDO0 pin", state.getSubGhzGdoPin(), forbidden);
+    uint8_t gdo0 = userInputManager.readValidatedPinNumber("CC1101 GDO0 GPIO", state.getSubGhzGdoPin(), forbidden);
     state.setSubGhzGdoPin(gdo0);
 
     float freq = state.getSubGhzFrequency(); 

--- a/src/Controllers/ThreeWireController.cpp
+++ b/src/Controllers/ThreeWireController.cpp
@@ -58,13 +58,13 @@ void ThreeWireController::handleConfig() {
     
     // Pins
     const auto& forbidden = state.getProtectedPins();
-    uint8_t cs = userInputManager.readValidatedPinNumber("CS pin", state.getThreeWireCsPin(), forbidden);
+    uint8_t cs = userInputManager.readValidatedPinNumber("CS GPIO", state.getThreeWireCsPin(), forbidden);
     state.setThreeWireCsPin(cs);
-    uint8_t sk = userInputManager.readValidatedPinNumber("SK pin", state.getThreeWireSkPin(), forbidden);
+    uint8_t sk = userInputManager.readValidatedPinNumber("SK GPIO", state.getThreeWireSkPin(), forbidden);
     state.setThreeWireSkPin(sk);
-    uint8_t di = userInputManager.readValidatedPinNumber("DI pin", state.getThreeWireDiPin(), forbidden);
+    uint8_t di = userInputManager.readValidatedPinNumber("DI GPIO", state.getThreeWireDiPin(), forbidden);
     state.setThreeWireDiPin(di);
-    uint8_t doPin = userInputManager.readValidatedPinNumber("DO pin", state.getThreeWireDoPin(), forbidden);
+    uint8_t doPin = userInputManager.readValidatedPinNumber("DO GPIO", state.getThreeWireDoPin(), forbidden);
     state.setThreeWireDoPin(doPin);
 
     // Configure the service, default value for eeprom

--- a/src/Controllers/TwoWireController.cpp
+++ b/src/Controllers/TwoWireController.cpp
@@ -45,7 +45,7 @@ void TwoWireController::handleSniff() {
     terminalView.println("2WIRE Sniffer: Running on CLK/IO... Press [ENTER] to stop\r\n");
 
     if (!twoWireService.startSniffer()) {
-        terminalView.println("Failed to start sniffer (check pins/config).");
+        terminalView.println("Failed to start sniffer (check GPIOs/config).");
         return;
     }
 
@@ -126,13 +126,13 @@ void TwoWireController::handleConfig() {
     terminalView.println("2WIRE Configuration:");
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t clk = userInputManager.readValidatedPinNumber("CLK pin", state.getTwoWireClkPin(), forbidden);
+    uint8_t clk = userInputManager.readValidatedPinNumber("CLK GPIO", state.getTwoWireClkPin(), forbidden);
     state.setTwoWireClkPin(clk);
 
-    uint8_t io = userInputManager.readValidatedPinNumber("IO pin", state.getTwoWireIoPin(), forbidden);
+    uint8_t io = userInputManager.readValidatedPinNumber("IO GPIO", state.getTwoWireIoPin(), forbidden);
     state.setTwoWireIoPin(io);
 
-    uint8_t rst = userInputManager.readValidatedPinNumber("RST pin", state.getTwoWireRstPin(), forbidden);
+    uint8_t rst = userInputManager.readValidatedPinNumber("RST GPIO", state.getTwoWireRstPin(), forbidden);
     state.setTwoWireRstPin(rst);
 
     twoWireService.configure(clk, io, rst);

--- a/src/Controllers/UartController.cpp
+++ b/src/Controllers/UartController.cpp
@@ -348,7 +348,7 @@ void UartController::handleScan() {
 
     // Limit selection to 8 pins max
     if (selectedPins.size() > 8) {
-        terminalView.println("Too many pins selected, limiting to first 8.");
+        terminalView.println("Too many GPIOs selected, limiting to first 8.");
         selectedPins.resize(8);
     }
 
@@ -360,11 +360,11 @@ void UartController::handleScan() {
     PinoutConfig cfg;
     PinoutConfig lastCfg;
 
-    terminalView.println("UART Scan: Measuring edges on pins... Press [ENTER] to stop.\n");
+    terminalView.println("UART Scan: Measuring edges on GPIOs... Press [ENTER] to stop.\n");
     terminalView.println(" [ℹ️  INFORMATION]");
-    terminalView.println(" The UART scan monitors GPIO pins to detect");
+    terminalView.println(" The UART scan monitors GPIO to detect");
     terminalView.println(" UART-like electrical activity (edges and timings).");
-    terminalView.println(" Pins showing activity are potential UART lines.");
+    terminalView.println(" GPIOs showing activity are potential UART lines.");
     terminalView.println("");
     delay(300); // since the loop below is fast, the message above may not be seen without delay
     
@@ -396,7 +396,7 @@ void UartController::handleScan() {
         if (now - lastPrint >= 1000) {
             lastPrint = now;
 
-            terminalView.println("Active pins:");
+            terminalView.println("Active GPIOs:");
 
             if (accum.empty()) {
                 terminalView.println("  (none)");
@@ -674,7 +674,7 @@ void UartController::handleXmodemSend(const std::string& path) {
 
     //Check SD mounted
     if (!sdMounted) {
-        terminalView.println("UART XMODEM: No SD card detected. Check SPI pins");
+        terminalView.println("UART XMODEM: No SD card detected. Check SPI GPIOs");
         return;
     }
 
@@ -720,7 +720,7 @@ void UartController::handleXmodemReceive(const std::string& path) {
 
     //Check SD mounted
     if (!sdMounted) {
-        terminalView.println("UART XMODEM: No SD card detected. Check SPI pins");
+        terminalView.println("UART XMODEM: No SD card detected. Check SPI GPIOs");
         return;
     }
 
@@ -772,10 +772,10 @@ void UartController::handleConfig() {
 
     const auto& forbidden = state.getProtectedPins();
 
-    uint8_t rxPin = userInputManager.readValidatedPinNumber("RX pin number", state.getUartRxPin(), forbidden);
+    uint8_t rxPin = userInputManager.readValidatedPinNumber("RX GPIO number", state.getUartRxPin(), forbidden);
     state.setUartRxPin(rxPin);
 
-    uint8_t txPin = userInputManager.readValidatedPinNumber("TX pin number", state.getUartTxPin(), forbidden);
+    uint8_t txPin = userInputManager.readValidatedPinNumber("TX GPIO number", state.getUartTxPin(), forbidden);
     state.setUartTxPin(txPin);
 
     uint32_t baud = userInputManager.readValidatedUint32("Baud rate", state.getUartBaudRate());

--- a/src/Controllers/UsbS3Controller.cpp
+++ b/src/Controllers/UsbS3Controller.cpp
@@ -459,21 +459,21 @@ Config
 void UsbS3Controller::handleConfig() {
     terminalView.println("USB Configuration:");
 
-    auto confirm = userInputManager.readYesNo("Configure SD card pins for USB?", false);
+    auto confirm = userInputManager.readYesNo("Configure SD card GPIOs for USB?", false);
 
     if (confirm) {
         const auto& forbidden = state.getProtectedPins();
     
-        uint8_t cs = userInputManager.readValidatedPinNumber("SD Card CS pin", state.getSdCardCsPin(), forbidden);
+        uint8_t cs = userInputManager.readValidatedPinNumber("SD Card CS GPIO", state.getSdCardCsPin(), forbidden);
         state.setSdCardCsPin(cs);
     
-        uint8_t clk = userInputManager.readValidatedPinNumber("SD Card CLK pin", state.getSdCardClkPin(), forbidden);
+        uint8_t clk = userInputManager.readValidatedPinNumber("SD Card CLK GPIO", state.getSdCardClkPin(), forbidden);
         state.setSdCardClkPin(clk);
     
-        uint8_t miso = userInputManager.readValidatedPinNumber("SD Card MISO pin", state.getSdCardMisoPin(), forbidden);
+        uint8_t miso = userInputManager.readValidatedPinNumber("SD Card MISO GPIO", state.getSdCardMisoPin(), forbidden);
         state.setSdCardMisoPin(miso);
     
-        uint8_t mosi = userInputManager.readValidatedPinNumber("SD Card MOSI pin", state.getSdCardMosiPin(), forbidden);
+        uint8_t mosi = userInputManager.readValidatedPinNumber("SD Card MOSI GPIO", state.getSdCardMosiPin(), forbidden);
         state.setSdCardMosiPin(mosi);
     }
 

--- a/src/Controllers/UtilityController.cpp
+++ b/src/Controllers/UtilityController.cpp
@@ -238,7 +238,7 @@ void UtilityController::handleLogicAnalyzer(const TerminalCommand& cmd) {
     uint8_t step = 1; // step of the trace display kind of a zoom
 
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: logic <pin>");
+        terminalView.println("Usage: logic <GPIO>");
         return;
     }
 
@@ -252,10 +252,10 @@ void UtilityController::handleLogicAnalyzer(const TerminalCommand& cmd) {
     }
 */
     if (state.isPinProtected(pin)) {
-        terminalView.println("Logic Analyzer: This pin is protected or reserved.");
+        terminalView.println("Logic Analyzer: This GPIO is protected or reserved.");
         return;
     }
-    terminalView.println("\nLogic Analyzer: Monitoring pin " + std::to_string(pin) + "... Press [ENTER] to stop.");
+    terminalView.println("\nLogic Analyzer: Monitoring GPIO " + std::to_string(pin) + "... Press [ENTER] to stop.");
     terminalView.println("Displaying waveform on the ESP32 screen...\n");
 
 
@@ -337,22 +337,22 @@ void UtilityController::handleAnalogic(const TerminalCommand& cmd) {
     uint8_t step = 1; // step of the trace display kind of a zoom
 
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: analogic <pin>");
+        terminalView.println("Usage: analogic <GPIO>");
         return;
     }
 
     // Verify protected pin
     uint8_t pin = argTransformer.toUint8(cmd.getSubcommand());
     if (state.isPinProtected(pin)) {
-        terminalView.println("Analogic: This pin is protected or reserved.");
+        terminalView.println("Analogic: This GPIO is protected or reserved.");
         return;
     }
     if (!state.isPinAnalog(pin)){
-        terminalView.println("Analogic: This pin is not an analog one");
+        terminalView.println("Analogic: This GPIO is not an analog one");
         return;
     };
 
-    terminalView.println("\nAnalogic: Monitoring pin " + std::to_string(pin) + "... Press [ENTER] to stop.");
+    terminalView.println("\nAnalogic: Monitoring GPIO " + std::to_string(pin) + "... Press [ENTER] to stop.");
     terminalView.println("Displaying waveform on the ESP32 screen...\n");
 
 
@@ -403,7 +403,7 @@ void UtilityController::handleAnalogic(const TerminalCommand& cmd) {
                 float voltage = (raw / 4095.0f) * 3.3f;
 
                 std::ostringstream oss;
-                oss << "   Analog pin " << static_cast<int>(pin)
+                oss << "   Analog GPIO " << static_cast<int>(pin)
                     << ": " << raw
                     << " (" << voltage << " V)";
                 terminalView.println(oss.str());
@@ -443,18 +443,18 @@ Wizard
 void UtilityController::handleWizard(const TerminalCommand& cmd) {
     // Validate pin argument
     if (cmd.getSubcommand().empty() || !argTransformer.isValidNumber(cmd.getSubcommand())) {
-        terminalView.println("Usage: wizard <pin>");
+        terminalView.println("Usage: wizard <GPIO>");
         return;
     }
 
     // Verify protected pin
     uint8_t pin = argTransformer.toUint8(cmd.getSubcommand());
     if (state.isPinProtected(pin)) {
-        terminalView.println("Wizard: This pin is protected or reserved.");
+        terminalView.println("Wizard: This GPIO is protected or reserved.");
         return;
     }
 
-    terminalView.println("\nWizard: Please wait, analyzing pin " + std::to_string(pin) + "... Press [ENTER] to stop.\n");
+    terminalView.println("\nWizard: Please wait, analyzing GPIO " + std::to_string(pin) + "... Press [ENTER] to stop.\n");
     pinAnalyzer.begin(pin);
     const bool doPullTest = false; // TODO: add argument to enable pull test if needed
 
@@ -476,7 +476,7 @@ void UtilityController::handleWizard(const TerminalCommand& cmd) {
             auto report = pinAnalyzer.buildReport(doPullTest);
             terminalView.print(pinAnalyzer.formatWizardReport(pin, report));
             pinAnalyzer.resetWindow();
-            terminalView.println("Wizard: Analyzing pin " + std::to_string(pin) + "... Press [ENTER] to stop.\n");
+            terminalView.println("Wizard: Analyzing GPIO " + std::to_string(pin) + "... Press [ENTER] to stop.\n");
         }
     }
 
@@ -493,19 +493,19 @@ void UtilityController::handleListen(const TerminalCommand& cmd) {
     if (!cmd.getSubcommand().empty() && argTransformer.isValidNumber(cmd.getSubcommand())) {
         pin = argTransformer.toUint8(cmd.getSubcommand());
     } else {
-        terminalView.println("Usage: listen <pin>");
+        terminalView.println("Usage: listen <GPIO>");
         return;
     }
 
     // Protected
     if (state.isPinProtected(pin)) {
-        terminalView.println("Listen: This pin is protected or reserved.");
+        terminalView.println("Listen: This GPIO is protected or reserved.");
         return;
     }
 
     // Used by I2S
     if (state.getI2sBclkPin() == pin || state.getI2sLrckPin() == pin || state.getI2sDataPin() == pin) {
-        terminalView.println("Listen: This pin is used by I2S.");
+        terminalView.println("Listen: This GPIO is used by I2S.");
         return;
     }
 
@@ -526,7 +526,7 @@ void UtilityController::handleListen(const TerminalCommand& cmd) {
                          "... Press [ENTER] to stop.\n");
 
     terminalView.println(" [ℹ️  INFORMATION] ");
-    terminalView.println(" Using I2S configured pins for audio output.");
+    terminalView.println(" Using I2S configured GPIOs for audio output.");
     terminalView.println(" You can set volume in the I2S mode settings.\n");
 
     //  params

--- a/src/Managers/UserInputManager.cpp
+++ b/src/Managers/UserInputManager.cpp
@@ -419,7 +419,7 @@ uint8_t UserInputManager::readValidatedPinNumber(const std::string& label, uint8
     while (true) {
         int val = readValidatedUint8(label, def, min, max);
         if (std::find(forbiddenPins.begin(), forbiddenPins.end(), val) != forbiddenPins.end()) {
-            terminalView.println("This pin is reserved/protected and cannot be used.");
+            terminalView.println("This GPIO is reserved/protected and cannot be used.");
             continue;
         }
         return val;
@@ -463,13 +463,13 @@ std::vector<uint8_t> UserInputManager::readValidatedPinGroup(
         while (ss >> val) {
             // Invalid
             if (val < 0 || val > 48) {
-                terminalView.println("Invalid pin: " + std::to_string(val));
+                terminalView.println("Invalid GPIO: " + std::to_string(val));
                 valid = false;
                 break;
             }
             // Protected
             if (std::find(protectedPins.begin(), protectedPins.end(), val) != protectedPins.end()) {
-                terminalView.println("Pin " + std::to_string(val) + " is protected/reserved.");
+                terminalView.println("GPIO " + std::to_string(val) + " is protected/reserved.");
                 valid = false;
                 break;
             }

--- a/src/Shells/GuideShell.cpp
+++ b/src/Shells/GuideShell.cpp
@@ -106,7 +106,7 @@ void GuideShell::cmdExamples() {
     terminalView.println("  monitor 0x13 500    (watch changes)");
     terminalView.println("");
 
-    terminalView.println("[DIO] Drive / observe pins:");
+    terminalView.println("[DIO] Drive / observe GPIOs:");
     terminalView.println("  mode dio");
     terminalView.println("  read 1");
     terminalView.println("  set 1 L");

--- a/src/Shells/HelpShell.cpp
+++ b/src/Shells/HelpShell.cpp
@@ -103,13 +103,13 @@ void HelpShell::cmdGeneral() {
         "mode [name]          - Set active mode",
         "man                  - Show firmware guide",
         "system               - Show system infos",
-        "profile              - Save/load pins config",
+        "profile              - Save/load GPIOs config",
         "alias                - Create shortcut",
         "hex [number]         - Convert dec/hex/bin",
-        "logic <pin>          - Logic analyzer",
-        "analogic <pin>       - Analogic plotter",
-        "wizard <pin>         - Pin activity analyzer",
-        "listen <pin>         - Pin activity to audio",
+        "logic <GPIO>         - Logic analyzer",
+        "analogic <GPIO>      - Analogic plotter",
+        "wizard <GPIO>        - GPIO activity analyzer",
+        "listen <GPIO>        - GPIO activity to audio",
         "repeat <count> <cmd> - Repeat command",
         "P                    - Enable pull-up",
         "p                    - Disable pull-up",
@@ -155,7 +155,7 @@ void HelpShell::cmdUart() {
         "xmodem <send> <path> - Send file via XMODEM",
         "xmodem <recv> <path> - Receive file via XMODEM",
         "config               - Configure settings",
-        "swap                 - Swap RX and TX pins",
+        "swap                 - Swap RX and TX GPIOs",
         "['Hello'] [r:64]...  - Instruction syntax"
     };
     printLines(lines, (int)(sizeof(lines) / sizeof(lines[0])));
@@ -191,7 +191,7 @@ void HelpShell::cmdI2c() {
         "eeprom [addr]        - I2C EEPROM operations",
         "recover              - Attempt bus recovery",
         "jam                  - Jam I2C bus with noise",
-        "swap                 - Swap SDA and SCL pins",
+        "swap                 - Swap SDA and SCL GPIOs",
         "config               - Configure settings",
         "[0x13 0x4B 0x1]      - Instruction syntax"
     };
@@ -235,20 +235,20 @@ void HelpShell::cmdThreeWire() {
 void HelpShell::cmdDio() {
     printHeader("DIO");
     static const char* const lines[] = {
-        "scan                 - Detect pins activity",
-        "pins                 - Show pins state",
-        "sniff <pin>          - Track toggle states",
-        "read <pin>           - Get pin state",
-        "set <pin> <H/L/I/O>  - Set pin state",
-        "pullup <pin>         - Set pin pullup",
-        "pulldown <pin>       - Set pin pulldown",
-        "pulse <pin> <us>     - Send pulse on pin",
-        "servo <pin> <angle>  - Set servo angle",
-        "pwm <pin> [frq duty%]- Set PWM on pin",
-        "toggle <pin> <ms>    - Toggle pin periodically",
-        "measure <pin> [ms]   - Calculate frequency",
-        "jam <pin> [min max]  - Random high/low states",
-        "reset <pin>          - Reset to default"
+        "scan                  - Detect pins activity",
+        "pins                  - Show pins state",
+        "sniff <GPIO>          - Track toggle states",
+        "read <GPIO>           - Get pin state",
+        "set <GPIO> <H/L/I/O>  - Set pin state",
+        "pullup <GPIO>         - Set pin pullup",
+        "pulldown <GPIO>       - Set pin pulldown",
+        "pulse <GPIO> <us>     - Send pulse on pin",
+        "servo <GPIO> <angle>  - Set servo angle",
+        "pwm <GPIO> [frq duty%]- Set PWM on pin",
+        "toggle <GPIO> <ms>    - Toggle pin periodically",
+        "measure <GPIO> [ms]   - Calculate frequency",
+        "jam <GPIO> [min max]  - Random high/low states",
+        "reset <GPIO>          - Reset to default"
     };
     printLines(lines, (int)(sizeof(lines) / sizeof(lines[0])));
 }

--- a/src/Shells/ProfileShell.cpp
+++ b/src/Shells/ProfileShell.cpp
@@ -14,7 +14,7 @@ ProfileShell::ProfileShell(ITerminalView& tv,
 
 void ProfileShell::run() {
     terminalView.println("\n=== Profiles ===");
-    terminalView.println("Load and save your pins config.");
+    terminalView.println("Load and save your GPIOs config.");
 
     while (true) {
         int choice = userInputManager.readValidatedChoiceIndex("Choose an action", actions, actionsCount, actionsCount-1);

--- a/src/Vendors/TembedWifiSetup.cpp
+++ b/src/Vendors/TembedWifiSetup.cpp
@@ -10,7 +10,7 @@
 #include "Inputs/InputKeys.h"
 #include "Views/TembedDeviceView.h"
 
-// ---------------- Pins ----------------
+// ---------------- GPIOs ----------------
 #ifdef DEVICE_TEMBEDS3CC1101
   #define TEMBED_PIN_ENCODE_A   4
   #define TEMBED_PIN_ENCODE_B   5

--- a/src/Vendors/i2c_sniffer.cpp
+++ b/src/Vendors/i2c_sniffer.cpp
@@ -6,7 +6,7 @@
  * It is not part of the I2C BUS. It is neither a Master, nor a Slave and puts no data to the lines.
  * It just listens and logs the communication.
  * 
- * Two pins as imput are attached to SDC and SDA lines.
+ * Two pins as input are attached to SDC and SDA lines.
  * Since the I2C communications runs on 400kHz so,
  * the tool that runs this program should be fast.
  * This was tested on an ESP32 bord Heltec WiFi Lora32 v2

--- a/src/Vendors/i2c_sniffer.h
+++ b/src/Vendors/i2c_sniffer.h
@@ -6,7 +6,7 @@
  * It is not part of the I2C BUS. It is neither a Master, nor a Slave and puts no data to the lines.
  * It just listens and logs the communication.
  * 
- * Two pins as imput are attached to SDC and SDA lines.
+ * Two pins as input are attached to SDC and SDA lines.
  * Since the I2C communications runs on 400kHz so,
  * the tool that runs this program should be fast.
  * This was tested on an ESP32 bord Heltec WiFi Lora32 v2

--- a/src/Views/M5DeviceView.cpp
+++ b/src/Views/M5DeviceView.cpp
@@ -314,8 +314,8 @@ void M5DeviceView::drawLogicTrace(uint8_t pin, const std::vector<uint8_t>& buffe
         if (x0 > canvasWidth - step) break;
     }
 
-    // Pin num
-    canvas.drawString("Pin " + String(pin), 5, 0);
+    // GPIO num
+    canvas.drawString("GPIO " + String(pin), 5, 0);
 
     // Center
     int x = (M5.Lcd.width() - canvasWidth) / 2;
@@ -346,7 +346,7 @@ void M5DeviceView::drawAnalogicTrace(uint8_t pin, const std::vector<uint8_t>& bu
     }
 
     // Pin num
-    canvas.drawString("Pin " + String(pin), 5, 0);
+    canvas.drawString("GPIO " + String(pin), 5, 0);
 
     canvas.pushSprite(0, 35);
     canvas.deleteSprite();

--- a/src/Views/TdisplayDeviceView.cpp
+++ b/src/Views/TdisplayDeviceView.cpp
@@ -80,7 +80,7 @@ void TdisplayDeviceView::drawLogicTrace(uint8_t pin, const std::vector<uint8_t>&
   tft.setTextFont(1);
   tft.setTextSize(1);
   tft.setCursor(10, 10);
-  tft.print("Pin ");
+  tft.print("GPIO ");
   tft.print(pin);
 
   const int traceY = 50;
@@ -114,7 +114,7 @@ void TdisplayDeviceView::drawAnalogicTrace(uint8_t pin, const std::vector<uint8_
   tft.setTextFont(1);
   tft.setTextSize(1);
   tft.setCursor(10, 10);
-  tft.print("Pin ");
+  tft.print("GPIO ");
   tft.print(pin);
 
   const int topY = 35;

--- a/src/Views/TembedDeviceView.cpp
+++ b/src/Views/TembedDeviceView.cpp
@@ -92,7 +92,7 @@ void TembedDeviceView::drawLogicTrace(uint8_t pin, const std::vector<uint8_t>& b
   tft.setTextFont(1);
   tft.setTextSize(1);
   tft.setCursor(10, 10);
-  tft.print("Pin ");
+  tft.print("GPIO ");
   tft.print(pin);
 
   const int traceY = 50;
@@ -126,7 +126,7 @@ void TembedDeviceView::drawAnalogicTrace(uint8_t pin, const std::vector<uint8_t>
   tft.setTextFont(1);
   tft.setTextSize(1);
   tft.setCursor(10, 10);
-  tft.print("Pin ");
+  tft.print("GPIO ");
   tft.print(pin);
 
   const int topY = 35;


### PR DESCRIPTION
Changed "pin" to "GPIO" in dialogs with the user to prevent ambiguous pin naming.

i2c_sniffer.cpp/.h
	corrected one typo in the files (imput -->input)