### PR TITLE
Added a sniff command to UART mode

### DIFF
--- a/src/Controllers/UartController.cpp
+++ b/src/Controllers/UartController.cpp
@@ -53,6 +53,7 @@ void UartController::handleCommand(const TerminalCommand& cmd) {
     else if (cmd.getRoot() == "glitch") handleGlitch();
     else if (cmd.getRoot() == "xmodem") handleXmodem(cmd);
     else if (cmd.getRoot() == "swap") handleSwap();
+    else if (cmd.getRoot() == "sniff") handleSniff();
     else if (cmd.getRoot() == "config") handleConfig();
     else handleHelp();
 }
@@ -996,6 +997,80 @@ void UartController::handleTrigger(const TerminalCommand& cmd) {
         }
     }
 }
+
+
+/*
+    sniff exchanges on a serial communication
+*/
+void UartController::handleSniff() {
+    GlobalState& state = GlobalState::getInstance();
+    enum source {NONE, UART1, UART2};
+
+    const unsigned long baud = state.getUartBaudRate();
+    const uint32_t config = state.getUartConfig();
+    const bool inverted = state.isUartInverted();
+
+    const uint8_t rxPin1 = state.getUartRxPin();
+    const uint8_t rxPin2 = state.getUartTxPin();
+    const int8_t noTxPin = -1;
+
+    int lastUart = NONE;
+
+    if (rxPin1 == rxPin2) {
+        terminalView.println("UART Sniff: RX and TX pins are identical.");
+        return;
+    }
+
+    if (state.isPinProtected(rxPin1) || state.isPinProtected(rxPin2)) {
+        terminalView.println("UART Sniff: protected pin.");
+        return;
+    }
+
+    terminalView.println("UART Sniff: press ENTER to stop");
+
+    UartService uart1;
+    UartService uart2;
+
+    uart1.configure(baud, config, rxPin1, noTxPin, inverted, &Serial1, false);
+    uart2.configure(baud, config, rxPin2, noTxPin, inverted, &Serial2, false);
+ 
+    uart1.flush();
+    uart2.flush();
+    while (uart1.available()) {uart1.read();}
+    while (uart2.available()) {uart2.read();}
+
+    while (true) {
+        char key = terminalInput.readChar();
+        if (key == '\r' || key == '\n') {
+            terminalView.println("\nUART Sniff: stopped");
+            break;
+        }
+
+       if (uart1.available() > 0) {
+            if (lastUart != UART1){
+                terminalView.print("\n\r\t[RX] ");
+                lastUart = UART1;
+            }
+            terminalView.print(std::string(1, uart1.read()));
+        }
+
+        if (uart2.available() > 0) {
+            if (lastUart != UART2){
+                terminalView.print("\n\r[TX] ");
+                lastUart = UART2;
+            }
+            terminalView.print(std::string(1, uart2.read()));
+        }
+
+        yield();
+    }
+
+    uart1.end();
+    uart2.end();
+
+    ensureConfigured();
+}
+
 
 /*
 Ensure Config

--- a/src/Controllers/UartController.h
+++ b/src/Controllers/UartController.h
@@ -97,6 +97,9 @@ private:
 
     // Handle trigger setup to send response on pattern match
     void handleTrigger(const TerminalCommand& cmd);
+
+    // sniff on a serial communication
+    void handleSniff();
     
     ITerminalView& terminalView;
     IDeviceView& deviceView;

--- a/src/Services/UartService.cpp
+++ b/src/Services/UartService.cpp
@@ -1,5 +1,6 @@
 #include "UartService.h"
 
+/*
 void UartService::configure(unsigned long baud, uint32_t config, uint8_t rx, uint8_t tx, bool inverted) {
     Serial1.end();
     Serial1.begin(baud, config, rx, tx, inverted);
@@ -26,9 +27,50 @@ void UartService::configure(unsigned long baud, uint32_t config, uint8_t rx, uin
         buffersAllocated = true;
     }
 }
+*/
+
+void UartService::configure(unsigned long baud,
+                            uint32_t config,
+                            uint8_t rx,
+                            uint8_t tx,
+                            bool inverted,
+                            HardwareSerial* serial,
+                            bool noBuffer) {
+
+    _serial = serial;
+
+    _serial->end();
+    _serial->begin(baud, config, rx, tx, inverted);
+
+    if (noBuffer) {
+        return;
+    }
+
+    if (!buffersAllocated) {
+
+        edgeIntervals = (uint32_t*) heap_caps_malloc(
+            sizeof(uint32_t) * 50,
+            MALLOC_CAP_INTERNAL
+        );
+
+        edgeCounts = (uint32_t*) heap_caps_malloc(
+            sizeof(uint32_t) * 64,
+            MALLOC_CAP_INTERNAL
+        );
+
+        if (!edgeIntervals || !edgeCounts) {
+            buffersAllocated = false;
+            return;
+        }
+
+        memset((void*)edgeCounts, 0, sizeof(uint32_t) * 64);
+
+        buffersAllocated = true;
+    }
+}
 
 void UartService::release() {
-    Serial1.end();
+    _serial->end();
 
     if (buffersAllocated) {
         heap_caps_free((void*)edgeIntervals);
@@ -40,7 +82,7 @@ void UartService::release() {
 }
 
 void UartService::end() {
-    Serial1.end();
+    _serial->end();
 }
 
 std::string UartService::readLine() {
@@ -48,19 +90,19 @@ std::string UartService::readLine() {
     bool lastWasCR = false;
 
     while (true) {
-        if (!Serial1.available()) continue;
+        if (!_serial->available()) continue;
         
-        char c = Serial1.read();
+        char c = _serial->read();
 
         if (c == '\r') {
             lastWasCR = true;
-            Serial1.println();
+            _serial->println();
             break;
         }
 
         if (c == '\n') {
             if (!lastWasCR) {
-                Serial1.println();
+                _serial->println();
                 break;
             }
             continue;
@@ -69,11 +111,11 @@ std::string UartService::readLine() {
         if (c == '\b' || c == 127) {
             if (!input.empty()) {
                 input.pop_back();
-                Serial1.print("\b \b");
+                _serial->print("\b \b");
             }
         } else {
             input += c;
-            Serial1.print(c);
+            _serial->print(c);
             lastWasCR = false;
         }
     }
@@ -82,27 +124,27 @@ std::string UartService::readLine() {
 }
 
 void UartService::print(const std::string& msg) {
-    Serial1.print(msg.c_str());
+    _serial->print(msg.c_str());
 }
 
 void UartService::println(const std::string& msg) {
-    Serial1.println(msg.c_str());
+    _serial->println(msg.c_str());
 }
 
 bool UartService::available() const {
-    return Serial1.available();
+    return _serial->available();
 }
 
 char UartService::read() {
-    return Serial1.read();
+    return _serial->read();
 }
 
 void UartService::write(char c) {
-    Serial1.write(c);
+    _serial->write(c);
 }
 
 void UartService::write(const std::string& str) {
-    Serial1.write(reinterpret_cast<const uint8_t*>(str.c_str()), str.length());
+    _serial->write(reinterpret_cast<const uint8_t*>(str.c_str()), str.length());
 }
 
 std::string UartService::executeByteCode(const std::vector<ByteCode>& bytecodes) {
@@ -115,15 +157,15 @@ std::string UartService::executeByteCode(const std::vector<ByteCode>& bytecodes)
         switch (code.getCommand()) {
             case ByteCodeEnum::Write:
                 for (uint32_t i = 0; i < code.getRepeat(); ++i) {
-                    Serial1.write(code.getData());
+                    _serial->write(code.getData());
                 }
                 break;
 
             case ByteCodeEnum::Read:
                 start = millis();
                 while (received < code.getRepeat() && (millis() - start < timeout)) {
-                    if (Serial1.available()) {
-                        char c = Serial1.read();
+                    if (_serial->available()) {
+                        char c = _serial->read();
                         result += c;
                         ++received;
                     } else {
@@ -149,11 +191,11 @@ std::string UartService::executeByteCode(const std::vector<ByteCode>& bytecodes)
 }
 
 void UartService::switchBaudrate(unsigned long newBaud) {
-    Serial1.updateBaudRate(newBaud);
+    _serial->updateBaudRate(newBaud);
 }
 
 void UartService::flush() {
-    Serial.flush();
+    _serial->flush();
 }
 
 void UartService::clearUartBuffer() {
@@ -213,7 +255,7 @@ void UartService::setXmodemSendHandler(void (*handler)(void*, size_t, byte*, siz
 }
 
 void UartService::initXmodem() {
-    xmodem.begin(Serial1, xmodemProtocol);
+    xmodem.begin(*_serial, xmodemProtocol);
     xmodem.setDataSize(xmodemBlockSize);
     xmodem.setIdSize(xmodemIdSize);
 }

--- a/src/Services/UartService.h
+++ b/src/Services/UartService.h
@@ -23,7 +23,7 @@ public:
         uint32_t approxBaud;
     };
 
-    void configure(unsigned long baud, uint32_t config, uint8_t rx, uint8_t tx, bool inverted);
+    void configure(unsigned long baud, uint32_t config, uint8_t rx, uint8_t tx, bool inverted, HardwareSerial* serial = &Serial1, bool noBuffer = false);
     void release();
     void print(const std::string& msg);
     void println(const std::string& msg);
@@ -95,4 +95,5 @@ private:
     };
 
     static constexpr size_t kBaudRatesCount = sizeof(kBaudRates) / sizeof(kBaudRates[0]);
+    HardwareSerial* _serial;
 };

--- a/src/Shells/HelpShell.cpp
+++ b/src/Shells/HelpShell.cpp
@@ -156,6 +156,7 @@ void HelpShell::cmdUart() {
         "xmodem <recv> <path> - Receive file via XMODEM",
         "config               - Configure settings",
         "swap                 - Swap RX and TX GPIOs",
+        "sniff                - View traffic on an UART",
         "['Hello'] [r:64]...  - Instruction syntax"
     };
     printLines(lines, (int)(sizeof(lines) / sizeof(lines[0])));


### PR DESCRIPTION
To address #99 issue the sniff command has been added to UART mode.
The sniff command monitors Rx and Tx lines of an UART.

UartService.cpp/.h
- Added parameters to configure() in order to create more than one instance of UartService.The main modification is giving the HardwareSerial to use. The modifications to configure()) are transparent for the code that is already using using it.

UartController.cpp/.h
        - Added handleSniff()

HelpShell.cpp
        - Added sniff to list of command in UART mode
Screen copy of sniff
- UART1 sends a message over Tx "Message xxxxx"
- UART2 sends an answer over Rx adding the number sent by UART one "Answer to xxxxx"
- once in a while UART2 sends a message of his own initiative "ghost message". The message is sent while UART1 is sending its own one.
<img width="440" height="904" alt="Capture d’écran du 2026-03-25 16-57-30" src="https://github.com/user-attachments/assets/a279cc73-f565-4260-bfc2-96d6104a1e35" />
