### PR TITLE
Fix Bluetooth scan crash (StoreProhibited) by using valid device name

### DIFF
--- a/src/Services/BluetoothService.cpp
+++ b/src/Services/BluetoothService.cpp
@@ -187,7 +187,7 @@ void BluetoothService::switchToMode(BluetoothMode newMode) {
 
     // Init new mode
     if (newMode == BluetoothMode::CLIENT || newMode == BluetoothMode::SERVER) {
-        BLEDevice::init(""); 
+        BLEDevice::init("Bus-Pirate-BT"); 
     }
 
     mode = newMode;


### PR DESCRIPTION
## Bug Description
Running `mode bluetooth` → `scan` on M5StickC Plus 2 causes a **StoreProhibited** crash (Guru Meditation Error, EXCVADDR=0x00000000).

## Reproduce
1. Flash v0.5 (or any release up to v1.5) on M5StickC Plus 2
2. Boot → `mode bluetooth` → `scan`
3. ESP32 panics: StoreProhibited at address 0x00000000

## Root Cause
In `BluetoothService::switchToMode()` (line 190):
```cpp
BLEDevice::init("");  // Empty device name - BUG
```

This calls `esp_ble_gap_set_device_name("")`, leaving the BLE GAP layer improperly initialized. When `esp_ble_gap_start_scanning()` runs, it dereferences a null pointer → StoreProhibited.

## Fix (1 line)
```diff
- BLEDevice::init("");  // Peut être changé si tu veux des logs personnalisés
+ BLEDevice::init("Bus-Pirate-BT");
```

All other `BLEDevice::init()` calls in the codebase use non-empty names:
- Line 33: `BLEDevice::init(deviceName)` — works
- Line 226: `BLEDevice::init("BLE-Client")` — works
- Line 355: `BLEDevice::init("Sniffer")` — works

## Affected versions
v0.5, v0.6, v0.7, v0.8, v0.9, v1.0, v1.1, v1.2, v1.3, v1.4, v1.5 — all releases have this bug.

## Build note
The project's `platformio.ini` uses `platform = espressif32` which now resolves to v55.x (breaking changes). To build, pin to `platformio/espressif32@^6.6.0` in the `[env:m5stick]` section.