### PR TITLE
fix(subghz): deinit CC1101 after bruteforce, jam, and replay

### DIFF
--- a/src/Controllers/SubGhzController.cpp
+++ b/src/Controllers/SubGhzController.cpp
@@ -280,6 +280,7 @@ void SubGhzController::handleReplayDecoded(const TerminalCommand&) {
 
     terminalView.println("SUBGHZ: Replay complete.\n");
     subGhzService.stopTxBitBang(); // ensure stopped
+    subGhzService.deinitRfModule();
 }
 
 /*
@@ -320,8 +321,10 @@ void SubGhzController::handleJam(const TerminalCommand&) {
     }
 
     subGhzService.stopTxBitBang();
+    subGhzService.deinitRfModule();
     terminalView.println("SUBGHZ Jam: Stopped by user.\n");
 }
+
 
 /*
 Band Jam
@@ -1179,11 +1182,15 @@ void SubGhzController::handleBruteforce() {
         if (cc == '\n' || cc == '\r') {
             terminalView.println("\nSUBGHZ BruteForce: Stopped by user.\n");
             subGhzService.stopTxBitBang();
+            subGhzService.deinitRfModule();
+
             return;
         }
     }
 
     subGhzService.stopTxBitBang();
+    subGhzService.deinitRfModule();
+
     terminalView.println("\nSUBGHZ Bruteforce: Done.\n");
 }
 

--- a/src/Services/SubGhzService.cpp
+++ b/src/Services/SubGhzService.cpp
@@ -807,6 +807,28 @@ bool SubGhzService::send(const SubGhzFileCommand& cmd) {
     }
 }
 
+void SubGhzService::deinitRfModule() {
+    if (!isConfigured_) return;
+
+    // Stop the CC1101 - exit RX/TX, turn off frequency synthesizer
+    ELECHOUSE_cc1101.setSidle();
+    
+    // Set GDO0 pin LOW
+    pinMode(gdo0_, OUTPUT);
+    digitalWrite(gdo0_, LOW);
+    
+    // Set CS pin HIGH and end SPI transaction
+    ELECHOUSE_cc1101.SpiEnd();
+    
+    // Also set CS as output and high to be safe
+    pinMode(ss_, OUTPUT);
+    digitalWrite(ss_, HIGH);
+    
+    // Return to RX mode on last configured frequency
+    ELECHOUSE_cc1101.SetRx(mhz_);
+}
+
+
 // Tembed S3 CC1101 specific
 
 void SubGhzService::initTembed() {

--- a/src/Services/SubGhzService.h
+++ b/src/Services/SubGhzService.h
@@ -70,6 +70,8 @@ public:
                           float rxBwKhz      = 200.0f,
                           uint8_t modulation = 2,    // 2 = OOK/ASK
                           bool packetMode    = true);
+    void deinitRfModule();
+
 
 private:
     bool    isConfigured_ = false;


### PR DESCRIPTION
## Bug

After stopping bruteforce, single-frequency jam, or replay in SUBGHZ mode, the CC1101 remains in TX mode, causing persistent carrier transmission. Only power-cycling stops it.

## Root Cause

Missing `deinitRfModule()` calls on exit paths of TX commands. The method existed in the upstream Bruce firmware but was not ported.

## Changes

### `src/Services/SubGhzService.h` / `.cpp`
- Added `deinitRfModule()` that:
  1. Sends SIDLE strobe to exit TX and turn off frequency synthesizer
  2. Forces GDO0 LOW
  3. Ends SPI with CS HIGH  
  4. Returns to RX mode via `SetRx(mhz_)`

### `src/Controllers/SubGhzController.cpp`
- Added `deinitRfModule()` calls in all 4 exit paths:
  - `handleBruteforce()` - user stop (ENTER) 
  - `handleBruteforce()` - natural completion
  - `handleJam()` - user stop (single-frequency mode)
  - `handleReplayDecoded()` - replay loop exit