### PR TITLE
Correct some inconsistencies of variables type in SPI and I2C

### DIFF
--- a/src/Services/I2cService.cpp
+++ b/src/Services/I2cService.cpp
@@ -513,11 +513,11 @@ bool I2cService::initEeprom(uint16_t chipSizeKb, uint8_t addr) {
     return eeprom.begin(addr);
 }
 
-bool I2cService::eepromWriteByte(uint16_t address, uint8_t value) {
+bool I2cService::eepromWriteByte(uint32_t address, uint8_t value) {
     return eeprom.write(address, value);
 }
 
-uint8_t I2cService::eepromReadByte(uint16_t address) {
+uint8_t I2cService::eepromReadByte(uint32_t address) {
     return eeprom.read(address);
 }
 

--- a/src/Services/I2cService.h
+++ b/src/Services/I2cService.h
@@ -70,8 +70,8 @@ public:
 
     // EEPROM
     bool initEeprom(uint16_t chipSizeKb = 512, uint8_t addr=0x50);
-    bool eepromWriteByte(uint16_t address, uint8_t value);
-    uint8_t eepromReadByte(uint16_t address);
+    bool eepromWriteByte(uint32_t address, uint8_t value);
+    uint8_t eepromReadByte(uint32_t address);
     bool eepromPutString(uint32_t address, const std::string& str);
     bool eepromGetString(uint32_t address, std::string& outStr);
     uint32_t eepromLength();

--- a/src/Shells/I2cEepromShell.cpp
+++ b/src/Shells/I2cEepromShell.cpp
@@ -111,21 +111,21 @@ void I2cEepromShell::cmdAnalyze() {
 
 void I2cEepromShell::cmdRead() {
     auto addrStr = userInputManager.readValidatedHexString("Start address (e.g., 00FF00) ", 0, true);
-    auto addr = argTransformer.parseHexOrDec16("0x" + addrStr);
+    auto addr = argTransformer.parseHexOrDec32("0x" + addrStr);
     uint32_t eepromSize = i2cService.eepromLength();
     if (addr >= eepromSize) {
         terminalView.println("\n❌ Error: Start address is beyond EEPROM size.");
         return;
     }
     
-    uint8_t count = userInputManager.readValidatedUint8("Number of bytes to read:", 16);
+    uint32_t count = userInputManager.readValidatedUint32("Number of bytes to read:", 16);
     terminalView.println("");
     if (addr + count > eepromSize) {
         count = eepromSize - addr;
     }
 
     const uint8_t bytesPerLine = 16;
-    for (uint16_t i = 0; i < count; i += bytesPerLine) {
+    for (uint32_t i = 0; i < count; i += bytesPerLine) {
         std::vector<uint8_t> line;
         for (uint8_t j = 0; j < bytesPerLine && (i + j) < count; ++j) {
             line.push_back(i2cService.eepromReadByte(addr + i + j));
@@ -138,7 +138,7 @@ void I2cEepromShell::cmdRead() {
 
 void I2cEepromShell::cmdWrite() {
     auto addrStr = userInputManager.readValidatedHexString("Start address:", 0, true);
-    auto addr = argTransformer.parseHexOrDec16("0x" + addrStr);
+    auto addr = argTransformer.parseHexOrDec32("0x" + addrStr);
     auto hexStr = userInputManager.readValidatedHexString("Enter byte values (e.g., 01 A5 FF...) ", 0, true);
     auto data = argTransformer.parseHexList(hexStr);
 

--- a/src/Shells/SpiEepromShell.cpp
+++ b/src/Shells/SpiEepromShell.cpp
@@ -133,7 +133,8 @@ void SpiEepromShell::cmdRead() {
 void SpiEepromShell::cmdWrite() {
     terminalView.println("\n✏️  Write EEPROM");
 
-    uint32_t addr = userInputManager.readValidatedUint32("Start address:", 0);
+   auto addrStr = userInputManager.readValidatedHexString("Start address (e.g., 00FF00) ", 0, true);
+    uint32_t addr = argTransformer.parseHexOrDec32("0x" + addrStr);
 
     if (userInputManager.readYesNo("Write an ASCII string?", true)) {
         terminalView.print("Enter ASCII string: ");

--- a/src/Shells/SpiFlashShell.cpp
+++ b/src/Shells/SpiFlashShell.cpp
@@ -310,7 +310,7 @@ void SpiFlashShell::cmdRead() {
     if (!checkFlashPresent()) return;
     
     auto addrStr = userInputManager.readValidatedHexString("Start address (e.g., 00FF00) ", 0, true);
-    auto address = argTransformer.parseHexOrDec16("0x" + addrStr);
+    auto address = argTransformer.parseHexOrDec32("0x" + addrStr);
     uint32_t count = userInputManager.readValidatedUint32("Number of bytes to read:", 16);
 
     // Read flash in chunks
@@ -415,7 +415,7 @@ void SpiFlashShell::cmdWrite() {
 
     // Adresse
     auto addrStr = userInputManager.readValidatedHexString("Start address (e.g., 00FF00) ", 0, true);
-    auto addr = argTransformer.parseHexOrDec16("0x" + addrStr);
+    auto addr = argTransformer.parseHexOrDec32("0x" + addrStr);
 
     std::vector<uint8_t> data;
 


### PR DESCRIPTION
i2cService, i2cEeepromShell, spiEepromshell, SpiFlashShell

Changes ensure that variables holding address in memory are uint32