### PR TITLE
feat: Glass2 OLED support for Cardputer

### DIFF
--- a/src/Views/CardputerTerminalView.cpp
+++ b/src/Views/CardputerTerminalView.cpp
@@ -5,6 +5,7 @@
 void CardputerTerminalView::initialize() {
     auto cfg = M5.config();
     M5Cardputer.begin(cfg);
+    glass2Init();
 
     M5Cardputer.Display.setRotation(1);
     M5Cardputer.Display.fillScreen(BACKGROUND_COLOR);
@@ -34,6 +35,7 @@ void CardputerTerminalView::initialize() {
 }
 
 void CardputerTerminalView::welcome(TerminalTypeEnum& /*terminalType*/, std::string& terminalInfos) {
+    glass2Show("BUS PIRATE");
     clear();
     println(" ____       ____  ");
     println("| __ )     |  _ \\");
@@ -110,6 +112,7 @@ void CardputerTerminalView::println(const std::string& text) {
 }
 
 void CardputerTerminalView::printPrompt(const std::string& mode) {
+    glass2Show("BUS PIRATE", mode.size() > 21 ? mode.substr(0, 21).c_str() : mode.c_str());
     instantRender = true;
     print(mode + "> ");
 }

--- a/src/Views/CardputerTerminalView.h
+++ b/src/Views/CardputerTerminalView.h
@@ -9,6 +9,7 @@
 
 #include <M5Cardputer.h>
 #include <Enums/TerminalTypeEnum.h>
+#include "glass2.h"
 #include "Interfaces/ITerminalView.h"
 #include "Inputs/InputKeys.h"
 #include "States/GlobalState.h"

--- a/src/glass2.h
+++ b/src/glass2.h
@@ -1,0 +1,24 @@
+#pragma once
+#ifdef DEVICE_CARDPUTER
+
+#include <M5UnitGLASS2.h>
+
+#define GLASS2_SDA 2
+#define GLASS2_SCL 1
+
+static M5UnitGLASS2 _g2(GLASS2_SDA, GLASS2_SCL);
+static bool _g2_ready = false;
+
+inline void glass2Init() {
+    _g2_ready = _g2.init();
+    if (_g2_ready) { _g2.fillScreen(TFT_BLACK); _g2.setTextColor(TFT_WHITE, TFT_BLACK); }
+}
+
+inline void glass2Show(const char* l1, const char* l2 = nullptr) {
+    if (!_g2_ready) return;
+    _g2.fillScreen(TFT_BLACK); _g2.setTextSize(1); _g2.setTextColor(TFT_WHITE, TFT_BLACK);
+    if (l1) { _g2.setCursor(0,  8); _g2.print(l1); }
+    if (l2) { _g2.setCursor(0, 40); _g2.print(l2); }
+}
+
+#endif // DEVICE_CARDPUTER


### PR DESCRIPTION
## Summary

Adds optional Grove Glass2 OLED (SSD1309, 128×64) support for the Cardputer. The OLED connects to the Grove port (SDA=G2, SCL=G1).

- Runtime-detected via `glass2Init()` — returns false if no Glass2 is connected, making all subsequent calls no-ops. No impact on devices without the OLED.
- On welcome: shows **BUS PIRATE** on line 1.
- On `printPrompt(mode)`: mirrors the current protocol mode to line 2 (e.g. `HIZ`, `I2C`, `UART`, `SPI`) — gives at-a-glance mode status without looking at the Cardputer screen.

**New file:** `src/glass2.h` — self-contained header using `M5UnitGLASS2` from M5GFX, which is already in the transitive dependency chain via `M5Cardputer` / `M5Unified`. No new `lib_deps` entry required.

## Test plan

- [ ] Build for `cardputer` environment — no new warnings or errors
- [ ] Flash to Cardputer with Glass2 connected — OLED shows `BUS PIRATE` at welcome, mode name updates as protocol is changed
- [ ] Flash to Cardputer without Glass2 — boots normally, no hang or error

🤖 Generated with [Claude Code](https://claude.com/claude-code)