### PR TITLE
Add support for Heltec WiFi LoRa 32(V3)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1246,3 +1246,100 @@ build_flags =
 
   ; --- JTAG ---
   -DJTAG_SCAN_PINS="\"1, 2, 3, 4\""
+
+
+; =========================================================
+; Heltec WiFi LoRa 32 V3 (CP210x UART — not native USB-CDC)
+; =========================================================
+[env:heltec_wifi_lora_32_V3]
+board = heltec_wifi_lora_32_V3
+upload_speed = 115200
+lib_deps =
+  crankyoldgit/IRremoteESP8266 @ ^2.9.0
+  ${env.lib_deps}
+build_unflags =
+  -D ARDUINO_USB_CDC_ON_BOOT=1
+  -D ARDUINO_USB_MODE=0
+  -D CONFIG_TINYUSB_CDC_ENABLED=1
+  -D CONFIG_TINYUSB_CDC_MAX_PORTS=2
+  -D CONFIG_TINYUSB_HID_ENABLED=1
+  -D CONFIG_TINYUSB_MSC_ENABLED=1
+build_flags =
+  ${env.build_flags}
+
+  -D ARDUINO_USB_CDC_ON_BOOT=0
+  -Wno-macro-redefined
+
+  -DDEVICE_S3DEVKIT
+
+  ; OLED 17/18/21, LoRa 8–14, flash 33–38, Vext 36, USB 43/44
+  ; SWD probe defaults: 4=SWDIO, 5=SWCLK, 6=RST, 1=UART RX
+  -DPROTECTED_PINS="\"0, 1, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 17, 18, 21, 33, 34, 35, 36, 37, 38, 43, 44\""
+
+  -DLED_PIN=35
+  -DLED_TYPE_RGB=false
+
+  -DUART_BAUD=115200
+  -DUART_RX_PIN=1
+  -DUART_TX_PIN=2
+
+  -DHDUART_BAUD=115200
+  -DHDUART_PIN=1
+
+  -DSPI_CS_PIN=6
+  -DSPI_CLK_PIN=5
+  -DSPI_MISO_PIN=7
+  -DSPI_MOSI_PIN=4
+
+  -DTWOWIRE_CLK_PIN=5
+  -DTWOWIRE_IO_PIN=4
+  -DTWOWIRE_RST_PIN=6
+
+  -DTHREEWIRE_CS_PIN=6
+  -DTHREEWIRE_SK_PIN=5
+  -DTHREEWIRE_DI_PIN=4
+  -DTHREEWIRE_DO_PIN=7
+
+  -DI2C_SCL_PIN=47
+  -DI2C_SDA_PIN=48
+  -DI2C_FREQ=100000
+
+  -DONEWIRE_PIN=7
+
+  -DIR_TX_PIN=2
+  -DIR_RX_PIN=1
+
+  -DLED_DATA_PIN=48
+  -DLED_CLOCK_PIN=47
+
+  -DI2S_BCLK_PIN=47
+  -DI2S_LRCK_PIN=48
+  -DI2S_DATA_PIN=7
+  -DI2S_SAMPLE_RATE=16000
+  -DI2S_BITS=16
+
+  -DCAN_CS_PIN=6
+  -DCAN_SCK_PIN=5
+  -DCAN_SI_PIN=4
+  -DCAN_SO_PIN=7
+  -DCAN_KBPS=125
+
+  -DETHERNET_CS_PIN=6
+  -DETHERNET_CLK_PIN=5
+  -DETHERNET_MISO_PIN=7
+  -DETHERNET_MOSI_PIN=4
+  -DETHERNET_IRQ_PIN=2
+
+  -DSUBGHZ_CS_PIN=6
+  -DSUBGHZ_SCK_PIN=5
+  -DSUBGHZ_SI_PIN=4
+  -DSUBGHZ_SO_PIN=7
+  -DSUBGHZ_GDO_PIN=2
+
+  -DRF24_CSN_PIN=6
+  -DRF24_CE_PIN=2
+  -DRF24_SCK_PIN=5
+  -DRF24_MISO_PIN=7
+  -DRF24_MOSI_PIN=4
+
+  -DJTAG_SCAN_PINS="\"4, 5, 6, 7\""

--- a/src/Adapters/AvrDudeBusPirateAdapter.cpp
+++ b/src/Adapters/AvrDudeBusPirateAdapter.cpp
@@ -1,5 +1,6 @@
 #include "AvrDudeBusPirateAdapter.h"
 #include "Inputs/InputKeys.h"
+#include "Utils/HostSerial.h"
 #include <cstring>
 #include <vector>
 
@@ -17,9 +18,9 @@ void AvrDudeBusPirateAdapter::run(const AvrDudeBusPirateConfig& adapterConfig, I
         config.frequency = DEFAULT_SPI_FREQUENCY;
     }
 
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
     Serial.setRxBufferSize(MAX_TRANSFER + 64);
-    Serial.begin();
+    hostSerialBegin();
 
     state = ProtocolState::WaitBbio;
     zeroCount = 0;

--- a/src/Adapters/FlashromSerprogAdapter.cpp
+++ b/src/Adapters/FlashromSerprogAdapter.cpp
@@ -1,5 +1,6 @@
 #include "FlashromSerprogAdapter.h"
 #include "Inputs/InputKeys.h"
+#include "Utils/HostSerial.h"
 #include <USBCDC.h>
 #include <vector>
 
@@ -46,11 +47,18 @@ void FlashromSerprogAdapter::run(const FlashromSerprogConfig& adapterConfig, IIn
         config.frequency = DEFAULT_SPI_FREQUENCY;
     }
 
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
+#if ARDUINO_USB_CDC_ON_BOOT
     Serial.setTxTimeoutMs(TX_TIMEOUT_MS);
+#endif
     Serial.setRxBufferSize(SERIAL_BUFFER_SIZE);
+#if ARDUINO_USB_CDC_ON_BOOT
     Serial.onEvent(onUsbEvent);
-    Serial.begin();
+#endif
+    hostSerialBegin();
+    if (hostSerialUartAlwaysConnected()) {
+        cdcConnected = true;
+    }
 
     initializeSpi();
     setPinDrivers(true);

--- a/src/Adapters/InfraredToyAdapter.cpp
+++ b/src/Adapters/InfraredToyAdapter.cpp
@@ -1,6 +1,7 @@
 #include "InfraredToyAdapter.h"
 
 #include "Inputs/InputKeys.h"
+#include "Utils/HostSerial.h"
 
 void InfraredToyAdapter::run(const InfraredToyConfig& config, IInput& input) {
     InfraredToyAdapter::config = config;
@@ -63,10 +64,10 @@ void InfraredToyAdapter::begin() {
 
     lastInputPollMs = millis();
 
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
     Serial.setRxBufferSize(SERIAL_RX_BUFFER_SIZE);
     Serial.setTimeout(0);
-    Serial.begin(115200);
+    hostSerialBegin();
 
     if (!allocateLazyBuffers()) {
         static constexpr char msg[] = "IR Toy adapter: buffer allocation failed\r\n";

--- a/src/Adapters/OpenOcdBusPirateAdapter.cpp
+++ b/src/Adapters/OpenOcdBusPirateAdapter.cpp
@@ -1,5 +1,6 @@
 #include "OpenOcdBusPirateAdapter.h"
 #include "Inputs/InputKeys.h"
+#include "Utils/HostSerial.h"
 #include "driver/gpio.h"
 #include <cstring>
 
@@ -57,9 +58,9 @@ inline void swdDelay() {
 void OpenOcdBusPirateAdapter::run(const OpenOcdBusPirateConfig& adapterConfig, IInput& input) {
     config = adapterConfig;
 
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
     Serial.setRxBufferSize((MAX_TAP_BYTES * 2) + 64);
-    Serial.begin();
+    hostSerialBegin();
 
     configurePins();
     runBitbangMode(input);

--- a/src/Adapters/SubGhzRawCdcAdapter.cpp
+++ b/src/Adapters/SubGhzRawCdcAdapter.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <cstdlib>
 #include "Inputs/InputKeys.h"
+#include "Utils/HostSerial.h"
 
 void SubGhzRawCdcAdapter::run(const SubGhzRawCdcConfig& adapterConfig, IInput& deviceInput) {
     input = &deviceInput;
@@ -48,10 +49,10 @@ void SubGhzRawCdcAdapter::begin() {
     rxReporting = false;
     lastInputPollMs = millis();
 
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
     Serial.setRxBufferSize(4096);
     Serial.setTimeout(0);
-    Serial.begin(runtimeConfig->baudrate);
+    hostSerialBegin(runtimeConfig->baudrate);
 
     if (!allocateLazyObjects()) {
         Serial.println("ERR:MEM");

--- a/src/Adapters/SumpLogicAnalyzerAdapter.cpp
+++ b/src/Adapters/SumpLogicAnalyzerAdapter.cpp
@@ -1,5 +1,6 @@
 #include "SumpLogicAnalyzerAdapter.h"
 #include "Inputs/InputKeys.h"
+#include "Utils/HostSerial.h"
 #include "driver/gpio.h"
 #include "esp_heap_caps.h"
 #include "esp_timer.h"
@@ -40,9 +41,9 @@ void IRAM_ATTR SumpLogicAnalyzerAdapter::waitUntilCycle(uint32_t targetCycle) {
 }
 
 void SumpLogicAnalyzerAdapter::run(const SumpLogicAnalyzerConfig& config, IInput& input) {
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
     Serial.setRxBufferSize(1024);
-    Serial.begin();
+    hostSerialBegin();
 
     configure(config, input);
 

--- a/src/Adapters/UsbUartBridgeAdapter.cpp
+++ b/src/Adapters/UsbUartBridgeAdapter.cpp
@@ -1,4 +1,5 @@
 #include "UsbUartBridgeAdapter.h"
+#include "Utils/HostSerial.h"
 #include "driver/gpio.h"
 #include <USBCDC.h>
 #include <algorithm>
@@ -150,11 +151,13 @@ void UsbUartBridgeAdapter::run(const UsbUartBridgeConfig& config, IInput& input)
     unsigned long lastLineCodingCheckMs = 0;
     uint32_t loopCounter = 0;
 
-    Serial.enableReboot(false);
+    hostSerialDisableReboot();
     Serial.setRxBufferSize(USB_RX_BUFFER_SIZE);
     Serial.setTimeout(0);
+#if ARDUINO_USB_CDC_ON_BOOT
     Serial.onEvent(ARDUINO_USB_CDC_LINE_CODING_EVENT, onLineCoding);
-    Serial.begin();
+#endif
+    hostSerialBegin();
 
     configureUart(DEFAULT_BAUD, SERIAL_8N1);
 

--- a/src/Inputs/SerialTerminalInput.cpp
+++ b/src/Inputs/SerialTerminalInput.cpp
@@ -1,5 +1,5 @@
 #include "SerialTerminalInput.h"
-#include <Arduino.h>
+#include "Utils/HostSerial.h"
 
 char SerialTerminalInput::handler() {
     while (!Serial.available()) {}
@@ -8,7 +8,7 @@ char SerialTerminalInput::handler() {
 
 void SerialTerminalInput::waitPress(uint32_t timeoutMs) {
     (void)timeoutMs; // currently not used
-    while (!Serial.available()) {}
+    hostSerialWaitForPress();
     Serial.read(); // discard
 }
 

--- a/src/Utils/HostSerial.h
+++ b/src/Utils/HostSerial.h
@@ -1,0 +1,68 @@
+#ifndef HOST_SERIAL_H
+#define HOST_SERIAL_H
+
+#include <Arduino.h>
+
+// Default host link baud when Serial uses UART (CP210x / CH340 bridges).
+constexpr unsigned long HOST_SERIAL_UART_BAUD = 115200;
+
+// ESP32-S3 PRG / BOOT (used when the host link has no keyboard in the monitor).
+constexpr uint8_t HOST_SERIAL_BOOT_BUTTON_PIN = 0;
+
+inline bool hostSerialUsesCdc() {
+#if ARDUINO_USB_CDC_ON_BOOT
+    return true;
+#else
+    return false;
+#endif
+}
+
+inline void hostSerialDisableReboot() {
+#if ARDUINO_USB_CDC_ON_BOOT
+    Serial.enableReboot(false);
+#endif
+}
+
+inline void hostSerialBegin(unsigned long baud = HOST_SERIAL_UART_BAUD) {
+#if ARDUINO_USB_CDC_ON_BOOT
+    (void)baud;
+    Serial.begin();
+#else
+    Serial.begin(baud);
+#endif
+}
+
+inline void hostSerialWaitReady(unsigned long baud = HOST_SERIAL_UART_BAUD) {
+    hostSerialBegin(baud);
+#if ARDUINO_USB_CDC_ON_BOOT
+    while (!Serial) {
+        delay(10);
+    }
+#endif
+}
+
+// UART host links are always "connected" (no USB CDC attach events).
+inline bool hostSerialUartAlwaysConnected() {
+    return !hostSerialUsesCdc();
+}
+
+// Wait for a host keypress; on UART-only headless boards, PRG also counts.
+inline void hostSerialWaitForPress() {
+#if defined(DEVICE_S3DEVKIT) && !ARDUINO_USB_CDC_ON_BOOT
+    pinMode(HOST_SERIAL_BOOT_BUTTON_PIN, INPUT_PULLUP);
+    while (!Serial.available()) {
+        if (digitalRead(HOST_SERIAL_BOOT_BUTTON_PIN) == LOW) {
+            delay(20);
+            while (digitalRead(HOST_SERIAL_BOOT_BUTTON_PIN) == LOW) {
+                delay(5);
+            }
+            return;
+        }
+        delay(5);
+    }
+#else
+    while (!Serial.available()) {}
+#endif
+}
+
+#endif // HOST_SERIAL_H

--- a/src/Views/SerialTerminalView.cpp
+++ b/src/Views/SerialTerminalView.cpp
@@ -1,10 +1,8 @@
 #include "SerialTerminalView.h"
+#include "Utils/HostSerial.h"
 
 void SerialTerminalView::initialize() {
-    Serial.begin(baudrate); // Serial USB CDC, to the PC
-    while (!Serial) {
-        delay(10);
-    }
+    hostSerialWaitReady(baudrate);
 }
 
 void SerialTerminalView::welcome(TerminalTypeEnum& terminalType, std::string& terminalInfos) {


### PR DESCRIPTION
This required a serial abstraction as well as a new platform env, because the Heltec doesn't use CDC for host serial communication.