### PR TITLE
T-Display: Adjusted delay for long press and shutdown to be more user friendly

### DIFF
--- a/src/Inputs/TdisplayInput.h
+++ b/src/Inputs/TdisplayInput.h
@@ -33,8 +33,8 @@ private:
     const uint8_t BTN_LONG = 4;
     const uint8_t BTN_SHUT = 8;
     const uint8_t LONG_PRESS_MIN = 5;
-    const uint8_t LONG_PRESS_MAX = 10;
-    const uint8_t LONG_PRESS_MIN_SHTDWN = 30;
+    const uint8_t LONG_PRESS_MAX = 20;
+    const uint8_t LONG_PRESS_MIN_SHTDWN = 50;
 };
 
 #endif

--- a/src/Selectors/HorizontalSelector.cpp
+++ b/src/Selectors/HorizontalSelector.cpp
@@ -26,10 +26,13 @@ int HorizontalSelector::select(
             case KEY_ARROW_LEFT:
                 currentIndex = (currentIndex > 0) ? currentIndex - 1 : options.size() - 1;
                 break;
-            case KEY_ARROW_RIGHT:
-                currentIndex = (currentIndex < options.size() - 1) ? currentIndex + 1 : 0;
+             case KEY_ARROW_RIGHT:
+            #if !defined(DEVICE_TDISPLAYS3)                
+               currentIndex = (currentIndex < options.size() - 1) ? currentIndex + 1 : 0;
                 break;
             case KEY_OK:
+            #endif
+
                 return currentIndex;
             default:
                 break;

--- a/src/Vendors/TdisplayWifiSetup.cpp
+++ b/src/Vendors/TdisplayWifiSetup.cpp
@@ -161,8 +161,8 @@ String selectWifiNetwork() {
     tft.setTextFont(2);
     tft.setTextSize(1);
     tft.setTextColor(HELP_COLOR, TFT_BLACK);
-    tft.drawString("Short press any button to change SSID", 10, tft.height() - 35);
-    tft.drawString("Long press top button to accept", 10, tft.height() - 20);
+    tft.drawString("Short press top button to change SSID", 10, tft.height() - 35);
+    tft.drawString("Short press bottom button to accept", 10, tft.height() - 20);
 
     while (true) {
         tft.fillRect(0, 40, tft.width(), tft.height() - 80, TFT_BLACK);
@@ -184,11 +184,9 @@ String selectWifiNetwork() {
         }
 
         char key = handler();
-        if (key == KEY_ARROW_RIGHT) {
-            selected = (selected - 1 + networksCount) % networksCount;
-        } else if (key == KEY_ARROW_LEFT) {
+        if (key == KEY_ARROW_LEFT) {
             selected = (selected + 1) % networksCount;
-        } else if (key == KEY_OK) {
+        } else if (key == KEY_ARROW_RIGHT) {
             return WiFi.SSID(selected);
         }
     }

--- a/src/Views/TdisplayDeviceView.cpp
+++ b/src/Views/TdisplayDeviceView.cpp
@@ -278,8 +278,8 @@ void TdisplayDeviceView::horizontalSelection(
 
   // Description 2 
   tft.setTextColor(HELP_COLOR, TFT_BLACK);
-  tft.drawString("Short press any button to change terminal", tft.width() / 2, tft.height() - 30);
-  tft.drawString("Long press top button to accept", tft.width() / 2, tft.height() - 12);
+  tft.drawString("Short press top button to change terminal", tft.width() / 2, tft.height() - 30);
+  tft.drawString("Short press bottom button to accept", tft.width() / 2, tft.height() - 12);
 
   // Box background + border
   tft.fillRoundRect(boxX, boxY, boxW, boxH, corner, DARK_GREY_RECT);


### PR DESCRIPTION
For T-Display
in Inputs/TdisplayInput.h
Changed limit for long press to 2s and time to shutdown to 5s.
So :
- 0.5s < long press < 2s
- more than 5s goes to shutdown
- time in between returns to selection menu

This to answer https://github.com/geo-tp/ESP32-Bit-Pirate/issues/147