### PR TITLE
Correction in env:xiao-esp32s3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1504,8 +1504,8 @@ build_flags =
   -DPROTECTED_PINS="\"19, 20, 22, 23, 24, 25, 45, 46\""
 
   ; --- Builtin LED ---
-  -DLED_PIN=48
-  -DLED_TYPE_RGB=true
+  -DLED_PIN=21
+  -DLED_TYPE_RGB=false
 
   ; --- OneWire ---
   -DONEWIRE_PIN=1


### PR DESCRIPTION
In platformio.ini
        Correction in [env:xiao-esp32s3] Xiao LED is on GPIO 21 and it is not an RGB led.