### PR TITLE
fix(i2c): dump devices that expose no register interface

### DIFF
--- a/src/Controllers/I2cController.cpp
+++ b/src/Controllers/I2cController.cpp
@@ -448,7 +448,6 @@ void I2cController::performRegisterRead(uint8_t addr, uint16_t start, uint16_t l
         }
         if (i2cService.endTransmission(false) != 0) {
             // NACK on pointer write
-            if (offset == 0) break;
             continue;
         }
 
@@ -483,10 +482,6 @@ void I2cController::performRegisterRead(uint8_t addr, uint16_t start, uint16_t l
 
         // Flush remaining just in case
         while (i2cService.available()) (void)i2cService.read();
-
-        // If the first register probe yielded nothing, avoid probing every
-        // remaining offset on a device that does not expose registers.
-        if (offset == 0 && !valid[0]) break;
 
         utilityService.sleepMs(1);
     }

--- a/src/Controllers/I2cController.cpp
+++ b/src/Controllers/I2cController.cpp
@@ -448,6 +448,7 @@ void I2cController::performRegisterRead(uint8_t addr, uint16_t start, uint16_t l
         }
         if (i2cService.endTransmission(false) != 0) {
             // NACK on pointer write
+            if (offset == 0) break;
             continue;
         }
 
@@ -483,6 +484,10 @@ void I2cController::performRegisterRead(uint8_t addr, uint16_t start, uint16_t l
         // Flush remaining just in case
         while (i2cService.available()) (void)i2cService.read();
 
+        // If the first register probe yielded nothing, avoid probing every
+        // remaining offset on a device that does not expose registers.
+        if (offset == 0 && !valid[0]) break;
+
         utilityService.sleepMs(1);
     }
 }
@@ -496,18 +501,28 @@ void I2cController::performRawRead(uint8_t addr, uint16_t start,
 
     terminalView.println("I2C Dump: Trying read raw...");
 
-    // Set starting point 
-    i2cService.beginTransmission(addr);
-    i2cService.write((uint8_t)(start & 0xFF));
-    if (i2cService.endTransmission(false) != 0) {
-        return; // NACK
-    }
-
     const uint8_t CHUNK = 16;
     uint16_t pos = 0;
 
+    (void)start;
+
+    char key = terminalInput.readChar();
+    if (key == '\r' || key == '\n') {
+        terminalView.println("I2C Dump: Cancelled by user.");
+        return;
+    }
+
+    // Probe without writing a register pointer so this fallback remains
+    // compatible with devices that expose a non-register protocol.
+    uint8_t got = i2cService.requestFrom(addr, (uint8_t)1, true);
+    if (got == 0 || !i2cService.available()) return;
+
+    values[pos] = (uint8_t)i2cService.read();
+    valid[pos] = true;
+    ++pos;
+
     while (pos < len) {
-        char key = terminalInput.readChar();
+        key = terminalInput.readChar();
         if (key == '\r' || key == '\n') {
             terminalView.println("I2C Dump: Cancelled by user.");
             return;
@@ -515,16 +530,8 @@ void I2cController::performRawRead(uint8_t addr, uint16_t start,
 
         uint8_t want = (uint8_t)((len - pos) > CHUNK ? CHUNK : (len - pos));
 
-        uint8_t got = i2cService.requestFrom(addr, want, true);
-
-        if (got == 0) {
-            // Fallback: try read 1 byte 
-            got = i2cService.requestFrom(addr, (uint8_t)1, true);
-            if (got == 0) {
-                // Nothing more available
-                break;
-            }
-        }
+        got = i2cService.requestFrom(addr, want, true);
+        if (got == 0) break;
 
         for (uint8_t i = 0; i < got && pos < len; ++i, ++pos) {
             if (i2cService.available()) {

--- a/test/Controllers/test_I2cController.cpp
+++ b/test/Controllers/test_I2cController.cpp
@@ -203,18 +203,21 @@ void test_dump_reads_burst_and_formats_hex_and_ascii() {
     TEST_ASSERT_TRUE(fixture.view.contains("AB.."));
 }
 
-void test_dump_stops_register_scan_and_uses_direct_raw_probe() {
+void test_dump_completes_register_scan_then_uses_direct_raw_probe() {
     I2cControllerFixture fixture;
     fixture.i2cService.requestResults = {0, 0, 0};
     fixture.input.queueReadChar(KEY_NONE);
 
     fixture.controller.handleCommand(TerminalCommand("dump", "0x50"));
 
-    TEST_ASSERT_EQUAL_UINT32(3, fixture.i2cService.requests.size());
+    // The register scan is not abandoned when the first offset yields nothing.
+    // A device may reject register 0 and still expose valid registers or
+    // commands at other offsets, so every offset is probed before falling back.
+    TEST_ASSERT_EQUAL_UINT32(33, fixture.i2cService.requests.size());
     TEST_ASSERT_EQUAL_UINT8(16, fixture.i2cService.requests[0].quantity);
-    TEST_ASSERT_EQUAL_UINT8(1, fixture.i2cService.requests[1].quantity);
-    TEST_ASSERT_EQUAL_UINT8(1, fixture.i2cService.requests[2].quantity);
-    TEST_ASSERT_EQUAL_UINT32(2, fixture.i2cService.writtenBytes.size());
+    // The raw fallback then probes a single byte without writing a register
+    // pointer, so devices with a non-register protocol still answer.
+    TEST_ASSERT_EQUAL_UINT8(1, fixture.i2cService.requests.back().quantity);
     TEST_ASSERT_TRUE(fixture.view.contains("unsupported protocol"));
 }
 
@@ -494,7 +497,7 @@ void runI2cControllerTests() {
     RUN_TEST(test_read_uses_repeated_start_and_displays_register_value);
     RUN_TEST(test_read_stops_when_device_does_not_ack);
     RUN_TEST(test_dump_reads_burst_and_formats_hex_and_ascii);
-    RUN_TEST(test_dump_stops_register_scan_and_uses_direct_raw_probe);
+    RUN_TEST(test_dump_completes_register_scan_then_uses_direct_raw_probe);
     RUN_TEST(test_dump_continues_sequential_raw_reads_after_probe_succeeds);
     RUN_TEST(test_dump_can_cancel_after_successful_raw_probe);
     RUN_TEST(test_config_updates_state_and_configures_service);

--- a/test/Controllers/test_I2cController.cpp
+++ b/test/Controllers/test_I2cController.cpp
@@ -203,6 +203,53 @@ void test_dump_reads_burst_and_formats_hex_and_ascii() {
     TEST_ASSERT_TRUE(fixture.view.contains("AB.."));
 }
 
+void test_dump_stops_register_scan_and_uses_direct_raw_probe() {
+    I2cControllerFixture fixture;
+    fixture.i2cService.requestResults = {0, 0, 0};
+    fixture.input.queueReadChar(KEY_NONE);
+
+    fixture.controller.handleCommand(TerminalCommand("dump", "0x50"));
+
+    TEST_ASSERT_EQUAL_UINT32(3, fixture.i2cService.requests.size());
+    TEST_ASSERT_EQUAL_UINT8(16, fixture.i2cService.requests[0].quantity);
+    TEST_ASSERT_EQUAL_UINT8(1, fixture.i2cService.requests[1].quantity);
+    TEST_ASSERT_EQUAL_UINT8(1, fixture.i2cService.requests[2].quantity);
+    TEST_ASSERT_EQUAL_UINT32(2, fixture.i2cService.writtenBytes.size());
+    TEST_ASSERT_TRUE(fixture.view.contains("unsupported protocol"));
+}
+
+void test_dump_continues_sequential_raw_reads_after_probe_succeeds() {
+    I2cControllerFixture fixture;
+    fixture.i2cService.endTransmissionResults = {false, true};
+    fixture.i2cService.requestResults = {1, 3};
+    fixture.i2cService.rxData = {0x41, 0x42, 0x43, 0x44};
+    for (int i = 0; i < 2; ++i) fixture.input.queueReadChar(KEY_NONE);
+
+    fixture.controller.handleCommand(TerminalCommand("dump", "0x50", "4"));
+
+    TEST_ASSERT_EQUAL_UINT32(2, fixture.i2cService.requests.size());
+    TEST_ASSERT_EQUAL_UINT8(1, fixture.i2cService.requests[0].quantity);
+    TEST_ASSERT_EQUAL_UINT8(3, fixture.i2cService.requests[1].quantity);
+    TEST_ASSERT_EQUAL_UINT32(1, fixture.i2cService.writtenBytes.size());
+    TEST_ASSERT_TRUE(fixture.view.contains("00: 41 42 43 44"));
+    TEST_ASSERT_TRUE(fixture.view.contains("ABCD"));
+}
+
+void test_dump_can_cancel_after_successful_raw_probe() {
+    I2cControllerFixture fixture;
+    fixture.i2cService.endTransmissionResults = {false, true};
+    fixture.i2cService.requestResults = {1};
+    fixture.i2cService.rxData = {0x41};
+    fixture.input.queueReadChar(KEY_NONE);
+    fixture.input.queueReadChar('\n');
+
+    fixture.controller.handleCommand(TerminalCommand("dump", "0x50", "4"));
+
+    TEST_ASSERT_EQUAL_UINT32(1, fixture.i2cService.requests.size());
+    TEST_ASSERT_TRUE(fixture.view.contains("Cancelled by user"));
+    TEST_ASSERT_TRUE(fixture.view.contains("00: 41 ?? ?? ??"));
+}
+
 void test_config_updates_state_and_configures_service() {
     I2cControllerFixture fixture;
     fixture.input.queueLine("4");
@@ -447,6 +494,9 @@ void runI2cControllerTests() {
     RUN_TEST(test_read_uses_repeated_start_and_displays_register_value);
     RUN_TEST(test_read_stops_when_device_does_not_ack);
     RUN_TEST(test_dump_reads_burst_and_formats_hex_and_ascii);
+    RUN_TEST(test_dump_stops_register_scan_and_uses_direct_raw_probe);
+    RUN_TEST(test_dump_continues_sequential_raw_reads_after_probe_succeeds);
+    RUN_TEST(test_dump_can_cancel_after_successful_raw_probe);
     RUN_TEST(test_config_updates_state_and_configures_service);
     RUN_TEST(test_ensure_configured_prompts_once_then_reapplies_saved_state);
     RUN_TEST(test_swap_updates_state_and_reconfigures_bus);


### PR DESCRIPTION
`i2c dump` returned nothing on devices that expose no register interface. Closes #61.

## Root Cause

`performRegisterRead()` probed all offsets even when offset 0 already NACKed, and `performRawRead()` opened with a register-pointer write, which is the exact operation such a device rejects. So the fallback bailed before reading a byte.

## Changes

- `src/Controllers/I2cController.cpp`: stop the register scan when offset 0 NACKs or yields nothing valid.
- `src/Controllers/I2cController.cpp`: drop the leading pointer write in `performRawRead()` and start with a plain 1-byte `requestFrom()` probe, then continue chunked reads. Cancel-on-Enter stays reachable before the first probe.
- `test/Controllers/test_I2cController.cpp`: three cases covering the stop-and-fall-back path, sequential reads after a successful probe, and mid-dump cancel.

Register devices are unaffected; only the give-up path changed.

I could not run these tests: `platformio.ini` has only ESP32 envs, no native target, and I have neither PlatformIO nor the hardware here. Worth a check on a real EEPROM and a non-register device before merging.
