### PR TITLE
Update platformio.ini to use platform-espressif32 55.03.37

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,8 @@
 ; =========================================================
 [env]
 board_build.partitions = partitions/app4M_spiffs_4M_8MB.csv
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; Temporary workaround: do not point to latest stable to avoid higher RAM usage
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 framework = arduino
 test_ignore = *
 monitor_filters = esp32_exception_decoder, colorize


### PR DESCRIPTION
Temporary workaround, avoid high RAM usage with the latest framework. Fixes https://github.com/geo-tp/ESP32-Bit-Pirate/issues/155