### PR TITLE
Fix IRrecv lifecycle on reconfiguration and increase raw buffer size

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,8 @@
 ; =========================================================
 [env]
 board_build.partitions = partitions/app4M_spiffs_4M_8MB.csv
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; Temporary workaround: do not point to latest stable to avoid higher RAM usage
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 framework = arduino
 test_ignore = *
 monitor_filters = esp32_exception_decoder, colorize

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,8 +14,7 @@
 ; =========================================================
 [env]
 board_build.partitions = partitions/app4M_spiffs_4M_8MB.csv
-; Temporary workaround: do not point to latest stable to avoid higher RAM usage
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
 framework = arduino
 test_ignore = *
 monitor_filters = esp32_exception_decoder, colorize

--- a/src/Services/InfraredService.cpp
+++ b/src/Services/InfraredService.cpp
@@ -15,22 +15,42 @@ IRremoteESP8266
 #include <IRutils.h>
 
 void InfraredService::configure(uint8_t tx, uint8_t rx) {
-    if (tx == _txPin && rx == _rxPin) return; // No change
+    if (tx == _txPin && rx == _rxPin) return;
 
     _txPin = tx;
     _rxPin = rx;
 
-    // TODO: delete ir obj make error message to serial with attached timers, find a workaround,
-    // It should be good for now if the user doesn't call configure with different pins a lot of times
-    // delete _sender;
-    // delete _receiver;
+    if (_receiver) {
+        _receiver->disableIRIn();
+        delete _receiver;
+        _receiver = nullptr;
+    }
+
+    if (_sender) {
+        delete _sender;
+        _sender = nullptr;
+    }
 
     _sender = new IRsend(_txPin);
     _sender->begin();
 
-    _receiver = new IRrecv(_rxPin);
+    static constexpr uint16_t kRawBufferSize = 512; //Increase raw buffer size from its default value of 100
+
+    _receiver = new IRrecv(_rxPin, kRawBufferSize);
 
     _configured = true;
+}
+
+InfraredService::~InfraredService() {
+    if (_receiver) {
+        _receiver->disableIRIn();
+        delete _receiver;
+        _receiver = nullptr;
+    }
+    if (_sender) {
+        delete _sender;
+        _sender = nullptr;
+    }
 }
 
 void InfraredService::startReceiver() {

--- a/src/Services/InfraredService.h
+++ b/src/Services/InfraredService.h
@@ -24,6 +24,7 @@ There are two backends for infrared:
 class InfraredService : public IInfraredService {
 public:
     InfraredService() = default;
+    ~InfraredService();
 
     void configure(uint8_t tx, uint8_t rx);
 


### PR DESCRIPTION
Linked issue: https://github.com/geo-tp/ESP32-Bit-Pirate/issues/154

This PR should fix the lifecycle management of the IR receiver in InfraredService when reconfiguring IR pins.
Previously, each call to configure() could allocate a new IRrecv instance without properly releasing the previous one, which risked leaking the internal raw buffer. This became especially relevant when increasing the capture buffer size to 512 entries.
Raw buffer size increased to 512 from the default 100 value, to be able to capture longer signals without missing packets.

This: https://github.com/crankyoldgit/IRremoteESP8266/pull/1984

should have fixed: "delete ir obj make error message to serial with attached timers, find a workaround"